### PR TITLE
GH-136: Removed parameters of external equation statements from scope.

### DIFF
--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl/src/com/ge/research/sadl/scoping/SADLScopeProvider.xtend
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl/src/com/ge/research/sadl/scoping/SADLScopeProvider.xtend
@@ -365,17 +365,21 @@ class SADLScopeProvider extends AbstractGlobalScopeDelegatingScopeProvider {
 	}
 	
 	private def void addElement(Map<QualifiedName, IEObjectDescription> scope, QualifiedName qn, EObject obj) {
-		
-		// Do not put parameters of external equation statements into the scope.
+
+		// Do not put parameters of external and local equation statements into the scope.
 		if (obj instanceof SadlResource) {
 			if (obj.eContainer instanceof SadlParameterDeclaration) {
 				val declaration = obj.eContainer as SadlParameterDeclaration;
-				if (declaration.eContainer instanceof ExternalEquationStatement) {
+				val container = declaration.eContainer;
+				if (container instanceof ExternalEquationStatement || container instanceof EquationStatement) {
 					return;
 				}
+			} else if (EcoreUtil2.getContainerOfType(obj, BinaryOperation) !== null) {
+				// Also filter out resources from the expression of any equations.
+				return;
 			}
 		}
-		
+
 		if (!scope.containsKey(qn)) {
 			scope.put(qn, new EObjectDescription(qn, obj, emptyMap))
 		}

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl/src/com/ge/research/sadl/scoping/SADLScopeProvider.xtend
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl/src/com/ge/research/sadl/scoping/SADLScopeProvider.xtend
@@ -24,6 +24,7 @@ import com.ge.research.sadl.model.DeclarationExtensions
 import com.ge.research.sadl.sADL.BinaryOperation
 import com.ge.research.sadl.sADL.EquationStatement
 import com.ge.research.sadl.sADL.Expression
+import com.ge.research.sadl.sADL.ExternalEquationStatement
 import com.ge.research.sadl.sADL.PropOfSubject
 import com.ge.research.sadl.sADL.QueryStatement
 import com.ge.research.sadl.sADL.RuleStatement
@@ -33,6 +34,7 @@ import com.ge.research.sadl.sADL.SadlImport
 import com.ge.research.sadl.sADL.SadlInstance
 import com.ge.research.sadl.sADL.SadlModel
 import com.ge.research.sadl.sADL.SadlMustBeOneOf
+import com.ge.research.sadl.sADL.SadlParameterDeclaration
 import com.ge.research.sadl.sADL.SadlProperty
 import com.ge.research.sadl.sADL.SadlResource
 import com.ge.research.sadl.sADL.SubjHasProp
@@ -363,6 +365,17 @@ class SADLScopeProvider extends AbstractGlobalScopeDelegatingScopeProvider {
 	}
 	
 	private def void addElement(Map<QualifiedName, IEObjectDescription> scope, QualifiedName qn, EObject obj) {
+		
+		// Do not put parameters of external equation statements into the scope.
+		if (obj instanceof SadlResource) {
+			if (obj.eContainer instanceof SadlParameterDeclaration) {
+				val declaration = obj.eContainer as SadlParameterDeclaration;
+				if (declaration.eContainer instanceof ExternalEquationStatement) {
+					return;
+				}
+			}
+		}
+		
 		if (!scope.containsKey(qn)) {
 			scope.put(qn, new EObjectDescription(qn, obj, emptyMap))
 		}


### PR DESCRIPTION
I have fixed the issue by simply filtering out the parameters of the external equation statements from the scope. Before merging this PR, I would need two more test cases to verify the issue;

An example where the `sum` method is used locally, and another when it is imported and used in another resource. Is that possible at all?

Enabled and adjusted tests corresponding test case.

Signed-off-by: Akos Kitta <kittaakos@gmail.com>