### PR TITLE
GH-173: Made sure property field editors call put value instead of set.

### DIFF
--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui/src/com/ge/research/sadl/ui/preferences/SadlRootPreferencePage.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui/src/com/ge/research/sadl/ui/preferences/SadlRootPreferencePage.java
@@ -17,6 +17,8 @@
  ***********************************************************************/
 package com.ge.research.sadl.ui.preferences;
 
+import java.lang.reflect.Field;
+
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.preferences.IPreferencesService;
 import org.eclipse.jface.preference.BooleanFieldEditor;
@@ -24,7 +26,6 @@ import org.eclipse.jface.preference.FileFieldEditor;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.preference.RadioGroupFieldEditor;
 import org.eclipse.jface.preference.StringFieldEditor;
-import org.eclipse.swt.widgets.Composite;
 import org.eclipse.xtext.ui.editor.preferences.LanguageRootPreferencePage;
 import org.eclipse.xtext.ui.editor.preferences.fields.LabelFieldEditor;
 
@@ -38,39 +39,187 @@ public class SadlRootPreferencePage extends LanguageRootPreferencePage {
 	
 	@SuppressWarnings("restriction")
 	@Override
-    protected void createFieldEditors() {
-        addField(new LabelFieldEditor("General SADL Settings", getFieldEditorParent()));
-        addField(new StringFieldEditor(SadlPreferences.SADL_BASE_URI.getId(), "Base URI", getFieldEditorParent()));
-        addField(new RadioGroupFieldEditor(SadlPreferences.OWL_MODEL_FORMAT.getId(), "Saved OWL model format :", 5, 
-        		new String[][] {
-        		{SadlPreferences.RDF_XML_ABBREV_FORMAT.getId(), SadlPreferences.RDF_XML_ABBREV_FORMAT.getId()}, 
-        		{SadlPreferences.RDF_XML_FORMAT.getId(), SadlPreferences.RDF_XML_FORMAT.getId()}, 
-        		{SadlPreferences.N3_FORMAT.getId(), SadlPreferences.N3_FORMAT.getId()}, 
-        		{SadlPreferences.N_TRIPLE_FORMAT.getId(), SadlPreferences.N_TRIPLE_FORMAT.getId()}, 
-        		{SadlPreferences.JENA_TDB.getId(), SadlPreferences.JENA_TDB.getId()},
-        		}, 
-        		getFieldEditorParent()));
-        addField(new RadioGroupFieldEditor("importBy", "Show import model list as:", 2, 
-        		new String[][] {{"Model Namespaces", SadlPreferences.MODEL_NAMESPACES.getId()}, {"SADL File Names", SadlPreferences.SADL_FILE_NAMES.getId()}}, getFieldEditorParent()));
-        addField(new BooleanFieldEditor(SadlPreferences.PREFIXES_ONLY_AS_NEEDED.getId(), "Show prefixes for imported concepts only when needed for disambiguation", getFieldEditorParent()));
-        addField(new BooleanFieldEditor(SadlPreferences.VALIDATE_BEFORE_TEST.getId(), "Validate before Testing", getFieldEditorParent()));
-        addField(new BooleanFieldEditor(SadlPreferences.TEST_WITH_KSERVER.getId(), "Test/Query with Knowledge Server", getFieldEditorParent()));
-        addField(new BooleanFieldEditor(SadlPreferences.NAMESPACE_IN_QUERY_RESULTS.getId(), "Show Namespaces in Query Results", getFieldEditorParent()));
-        addField(new BooleanFieldEditor(SadlPreferences.SHOW_TIMING_INFORMATION.getId(), "Show Timing Informaton (Build, Reasoning)", getFieldEditorParent()));
-        addField(new RadioGroupFieldEditor("dmyOrder", "Interpret Date 10/11/2012 as:", 2, 
-        		new String[][] {{"MM/DD/YYYY", SadlPreferences.DMY_ORDER_MDY.getId()}, 
-        						{"DD/MM/YYYY", SadlPreferences.DMY_ORDER_DMY.getId()}}, getFieldEditorParent()));
-        addField(new BooleanFieldEditor(SadlPreferences.DEEP_VALIDATION_OFF.getId(), "Disable Deep Validation of Model", getFieldEditorParent()));
-        addField(new StringFieldEditor(SadlPreferences.GRAPH_RENDERER_CLASS.getId(), "Graph renderer package and class", getFieldEditorParent()));
-        addField(new BooleanFieldEditor(SadlPreferences.CHECK_FOR_AMBIGUOUS_NAMES.getId(), "Check for ambiguous names", getFieldEditorParent()));
-//        addField(new BooleanFieldEditor(SadlPreferences.DISABLE_TYPE_CHECKING.getId(), "Disable type checking of model", getFieldEditorParent()));
-        addField(new BooleanFieldEditor(SadlPreferences.TYPE_CHECKING_WARNING_ONLY.getId(), "Type checking issues as warning only", getFieldEditorParent()));
-	    addField(new BooleanFieldEditor(SadlPreferences.IGNORE_UNITTEDQUANTITIES.getId(), "Ignore Unitted Quantities (treat as numeric only) during translation", getFieldEditorParent()));
-	    addField(new BooleanFieldEditor(SadlPreferences.USE_IMPLIED_PROPERTIES_IN_TRANSLATION.getId(), "Include implied properties in translation", getFieldEditorParent()));
-//	    addField(new BooleanFieldEditor(SadlPreferences.ENABLE_METRICS_COLLECTION.getId(), "Enable metrics collection during project build", getFieldEditorParent()));
-	    addField(new BooleanFieldEditor(SadlPreferences.GENERATE_METRICS_REPORT_ON_CLEAN_BUILD.getId(), "Generate metrics report during project clean/build", getFieldEditorParent()));
-		addField(new FileFieldEditor(SadlPreferences.METRICS_QUERY_FILENAME.getId(), "File containing metric queries: ", getFieldEditorParent()));
-    }
+	protected void createFieldEditors() {
+		addField(new LabelFieldEditor("General SADL Settings", getFieldEditorParent()));
+		addField(new StringFieldEditor(SadlPreferences.SADL_BASE_URI.getId(), "Base URI", getFieldEditorParent()) {
+
+			@Override
+			protected void doStore() {
+				getPreferenceStore().putValue(getPreferenceName(), getTextControl().getText());
+			}
+
+		});
+		addField(new RadioGroupFieldEditor(SadlPreferences.OWL_MODEL_FORMAT.getId(), "Saved OWL model format :", 5,
+				new String[][] {
+						{ SadlPreferences.RDF_XML_ABBREV_FORMAT.getId(),
+								SadlPreferences.RDF_XML_ABBREV_FORMAT.getId() },
+						{ SadlPreferences.RDF_XML_FORMAT.getId(), SadlPreferences.RDF_XML_FORMAT.getId() },
+						{ SadlPreferences.N3_FORMAT.getId(), SadlPreferences.N3_FORMAT.getId() },
+						{ SadlPreferences.N_TRIPLE_FORMAT.getId(), SadlPreferences.N_TRIPLE_FORMAT.getId() },
+						{ SadlPreferences.JENA_TDB.getId(), SadlPreferences.JENA_TDB.getId() }, },
+				getFieldEditorParent()) {
+
+			@Override
+			protected void doStore() {
+				doStoreFieldEditorValue(this);
+			}
+
+		});
+		addField(
+				new RadioGroupFieldEditor("importBy", "Show import model list as:", 2,
+						new String[][] { { "Model Namespaces", SadlPreferences.MODEL_NAMESPACES.getId() },
+								{ "SADL File Names", SadlPreferences.SADL_FILE_NAMES.getId() } },
+						getFieldEditorParent()) {
+
+					@Override
+					protected void doStore() {
+						doStoreFieldEditorValue(this);
+					}
+
+				});
+		addField(new BooleanFieldEditor(SadlPreferences.PREFIXES_ONLY_AS_NEEDED.getId(),
+				"Show prefixes for imported concepts only when needed for disambiguation", getFieldEditorParent()) {
+
+			@Override
+			protected void doStore() {
+				getPreferenceStore().putValue(getPreferenceName(), Boolean.toString(getBooleanValue()));
+			}
+
+		});
+		addField(new BooleanFieldEditor(SadlPreferences.VALIDATE_BEFORE_TEST.getId(), "Validate before Testing",
+				getFieldEditorParent()) {
+
+			@Override
+			protected void doStore() {
+				getPreferenceStore().putValue(getPreferenceName(), Boolean.toString(getBooleanValue()));
+			}
+
+		});
+		addField(new BooleanFieldEditor(SadlPreferences.TEST_WITH_KSERVER.getId(), "Test/Query with Knowledge Server",
+				getFieldEditorParent()) {
+
+			@Override
+			protected void doStore() {
+				getPreferenceStore().putValue(getPreferenceName(), Boolean.toString(getBooleanValue()));
+			}
+
+		});
+		addField(new BooleanFieldEditor(SadlPreferences.NAMESPACE_IN_QUERY_RESULTS.getId(),
+				"Show Namespaces in Query Results", getFieldEditorParent()) {
+
+			@Override
+			protected void doStore() {
+				getPreferenceStore().putValue(getPreferenceName(), Boolean.toString(getBooleanValue()));
+			}
+
+		});
+		addField(new BooleanFieldEditor(SadlPreferences.SHOW_TIMING_INFORMATION.getId(),
+				"Show Timing Informaton (Build, Reasoning)", getFieldEditorParent()) {
+
+			@Override
+			protected void doStore() {
+				getPreferenceStore().putValue(getPreferenceName(), Boolean.toString(getBooleanValue()));
+			}
+
+		});
+		addField(new RadioGroupFieldEditor("dmyOrder", "Interpret Date 10/11/2012 as:", 2,
+				new String[][] { { "MM/DD/YYYY", SadlPreferences.DMY_ORDER_MDY.getId() },
+						{ "DD/MM/YYYY", SadlPreferences.DMY_ORDER_DMY.getId() } },
+				getFieldEditorParent()) {
+
+			@Override
+			protected void doStore() {
+				doStoreFieldEditorValue(this);
+			}
+
+		});
+		addField(new BooleanFieldEditor(SadlPreferences.DEEP_VALIDATION_OFF.getId(), "Disable Deep Validation of Model",
+				getFieldEditorParent()) {
+
+			@Override
+			protected void doStore() {
+				getPreferenceStore().putValue(getPreferenceName(), Boolean.toString(getBooleanValue()));
+			}
+
+		});
+		addField(new StringFieldEditor(SadlPreferences.GRAPH_RENDERER_CLASS.getId(), "Graph renderer package and class",
+				getFieldEditorParent()) {
+
+			@Override
+			protected void doStore() {
+				getPreferenceStore().putValue(getPreferenceName(), getTextControl().getText());
+			}
+
+		});
+		addField(new BooleanFieldEditor(SadlPreferences.CHECK_FOR_AMBIGUOUS_NAMES.getId(), "Check for ambiguous names",
+				getFieldEditorParent()) {
+
+			@Override
+			protected void doStore() {
+				getPreferenceStore().putValue(getPreferenceName(), Boolean.toString(getBooleanValue()));
+			}
+
+		});
+		// addField(new BooleanFieldEditor(SadlPreferences.DISABLE_TYPE_CHECKING.getId(), "Disable type checking of model", getFieldEditorParent()));
+		addField(new BooleanFieldEditor(SadlPreferences.TYPE_CHECKING_WARNING_ONLY.getId(),
+				"Type checking issues as warning only", getFieldEditorParent()) {
+
+			@Override
+			protected void doStore() {
+				getPreferenceStore().putValue(getPreferenceName(), Boolean.toString(getBooleanValue()));
+			}
+
+		});
+		addField(new BooleanFieldEditor(SadlPreferences.IGNORE_UNITTEDQUANTITIES.getId(),
+				"Ignore Unitted Quantities (treat as numeric only) during translation", getFieldEditorParent()) {
+
+			@Override
+			protected void doStore() {
+				getPreferenceStore().putValue(getPreferenceName(), Boolean.toString(getBooleanValue()));
+			}
+
+		});
+		addField(new BooleanFieldEditor(SadlPreferences.USE_IMPLIED_PROPERTIES_IN_TRANSLATION.getId(),
+				"Include implied properties in translation", getFieldEditorParent()) {
+
+			@Override
+			protected void doStore() {
+				getPreferenceStore().putValue(getPreferenceName(), Boolean.toString(getBooleanValue()));
+			}
+		});
+		// addField(new BooleanFieldEditor(SadlPreferences.ENABLE_METRICS_COLLECTION.getId(), "Enable metrics collection during project build", getFieldEditorParent()));
+		addField(new BooleanFieldEditor(SadlPreferences.GENERATE_METRICS_REPORT_ON_CLEAN_BUILD.getId(),
+				"Generate metrics report during project clean/build", getFieldEditorParent()) {
+			@Override
+			protected void doStore() {
+				getPreferenceStore().putValue(getPreferenceName(), Boolean.toString(getBooleanValue()));
+			}
+		});
+		addField(new FileFieldEditor(SadlPreferences.METRICS_QUERY_FILENAME.getId(), "File containing metric queries: ",
+				getFieldEditorParent()) {
+
+			@Override
+			protected void doStore() {
+				getPreferenceStore().putValue(getPreferenceName(), getTextControl().getText());
+			}
+
+		});
+	}
+	
+	private void doStoreFieldEditorValue(RadioGroupFieldEditor editor) {
+		try {
+			Field field = RadioGroupFieldEditor.class.getDeclaredField("value");
+			field.setAccessible(true);
+			Object value = field.get(editor);
+			if (value instanceof String) {
+				editor.getPreferenceStore().putValue(editor.getPreferenceName(), (String) value);
+			} else {
+				editor.getPreferenceStore().setToDefault(editor.getPreferenceName());
+			}
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
 	
 	@Override
 	protected void performDefaults() {


### PR DESCRIPTION
Task: #173.

This is just a quick workaround for the project-specific related
preferences defect (xtext-eclipse/issues/238). Setting the values
deletes the project-specific preference entry from the store in some
cases. So that the workspace one will be used even if the project-level
preferences are enabled.

Signed-off-by: Akos Kitta <kittaakos@gmail.com>