### PR TITLE
GH-177: Fixed SADL3 update site issue.

### DIFF
--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.feature/feature.xml
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.feature/feature.xml
@@ -69,6 +69,10 @@ SADL also includes POJava licensed under Apache License V2.0.
          id="org.eclipse.emf.common.ui"
          version="0.0.0"/>
 
+   <includes
+         id="org.eclipse.lsp4j.sdk"
+         version="0.0.0"/>
+
    <plugin
          id="com.ge.research.sadl"
          download-size="0"
@@ -176,6 +180,34 @@ SADL also includes POJava licensed under Apache License V2.0.
 
    <plugin
          id="com.ge.research.sadl.errorgenerator"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.lsp4j"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.lsp4j.generator"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.lsp4j.jsonrpc"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="com.google.gson"
          download-size="0"
          install-size="0"
          version="0.0.0"


### PR DESCRIPTION
I have verified it locally. I ran the build locally, and I have managed to install the SADL3 dependencies to a brand new Eclipse IDE from the local p2 archive.

Task: #177

Signed-off-by: Akos Kitta <kittaakos@gmail.com>