### PR TITLE
[WIP] GH-199: Exported the simple FQ name of the SADL resources.

### DIFF
--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui.tests/META-INF/MANIFEST.MF
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui.tests/META-INF/MANIFEST.MF
@@ -16,7 +16,8 @@ Require-Bundle: com.ge.research.sadl.ui,
  org.junit;bundle-version="4.12.0",
  com.ge.research.sadl.jena,
  com.ge.research.jena,
- com.ge.research.sadl.tests
+ com.ge.research.sadl.tests,
+ org.eclipse.ui.ide
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: com.ge.research.sadl.ui.tests;x-internal=true,
  com.ge.research.sadl.ui.tests.contentassist

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui.tests/src/com/ge/research/sadl/ui/tests/GH_199_CheckAffectedResourcesTest.xtend
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui.tests/src/com/ge/research/sadl/ui/tests/GH_199_CheckAffectedResourcesTest.xtend
@@ -1,0 +1,57 @@
+/************************************************************************
+ * Copyright © 2007-2017 - General Electric Company, All Rights Reserved
+ * 
+ * Project: SADL
+ * 
+ * Description: The Semantic Application Design Language (SADL) is a
+ * language for building semantic models and expressing rules that
+ * capture additional domain knowledge. The SADL-IDE (integrated
+ * development environment) is a set of Eclipse plug-ins that
+ * support the editing and testing of semantic models using the
+ * SADL language.
+ * 
+ * This software is distributed "AS-IS" without ANY WARRANTIES
+ * and licensed under the Eclipse Public License - v 1.0
+ * which is available at http://www.eclipse.org/org/documents/epl-v10.php
+ * 
+ ***********************************************************************/
+package com.ge.research.sadl.ui.tests
+
+import org.junit.Test
+import static org.eclipse.core.resources.IMarker.*
+import static org.eclipse.core.resources.IResource.*
+
+/**
+ * Test for checking whether transitive downstream resources get rebuilt when a change
+ * occurs in the in the upstream resource.
+ * 
+ * @author akos.kitta
+ */
+class GH_199_CheckAffectedResourcesTest extends AbstractSadlPlatformTest {
+	
+	@Test
+	def void checkTransitiveDownstreamGetsRebuilt() {
+		createFile('A.sadl', '''
+			uri "http://sadl.org/A.sadl".
+			// AAA is a class.
+		''');
+		createFile('B.sadl', '''
+			uri "http://sadl.org/B.sadl".
+			import "http://sadl.org/A.sadl".
+		''');
+		val downstreamFile = createFile('C.sadl', '''
+			uri "http://sadl.org/C.sadl".
+			import "http://sadl.org/B.sadl".
+			MyAAA is a AAA.
+		''');
+		assertEquals(SEVERITY_ERROR, downstreamFile.findMaxProblemSeverity(PROBLEM, true, DEPTH_INFINITE));
+		
+		setFileContent('A.sadl', '''
+			uri "http://sadl.org/A.sadl".
+			AAA is a class.
+		''');
+		assertEquals(/*No errors/warnings.*/ -1, downstreamFile.findMaxProblemSeverity(PROBLEM, true, DEPTH_INFINITE));
+		
+	}
+	
+}

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl/src/com/ge/research/sadl/resource/ResourceDescriptionStrategy.xtend
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl/src/com/ge/research/sadl/resource/ResourceDescriptionStrategy.xtend
@@ -31,11 +31,16 @@ class ResourceDescriptionStrategy extends DefaultResourceDescriptionStrategy {
 	@Inject
 	extension UserDataHelper;
 	
-	@Override
 	override createEObjectDescriptions(EObject eObject, IAcceptor<IEObjectDescription> acceptor) {
 		val qualifiedName = qualifiedNameProvider.getFullyQualifiedName(eObject);
 		if (qualifiedName !== null) {
 			acceptor.accept(EObjectDescription.create(qualifiedName, eObject, eObject.createUserData));
+			if (qualifiedName.segmentCount > 1) {
+				// Export the simple name of the SADL resources, so that the resource description manager
+				// can mark a resource as `affected` when comparing the imported names of the candidates
+				// with the exported name of the deltas.
+				acceptor.accept(EObjectDescription.create(qualifiedName.lastSegment, eObject, eObject.createUserData));	
+			}
 		}
 		return true;
 	}


### PR DESCRIPTION
Do not merge yet.

Task: #199 

Fixes the `isAffected` issue when deciding whether a transitive
downstream resource is affected after changing the upstream resource.

Signed-off-by: Akos Kitta <kittaakos@gmail.com>