### PR TITLE
GH-168: Added missing class and datatype property support.

### DIFF
--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.tests/src/com/ge/research/sadl/tests/model/DeclarationExtensionsTest.xtend
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.tests/src/com/ge/research/sadl/tests/model/DeclarationExtensionsTest.xtend
@@ -32,7 +32,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 import static org.junit.Assert.*
-import org.junit.Ignore
 
 @RunWith(XtextRunner)
 @InjectWith(SADLInjectorProvider)
@@ -198,7 +197,6 @@ class DeclarationExtensionsTest {
 		assertEquals(OntConceptType.CLASS, name2resource.get('Rock').ontConceptType)
 	}
 	
-	@Ignore ("When GH-168 is fixed this ignore can be removed")
 	@Test def void testGetOntConceptType_08() {
 		val model = '''
 			uri "http://sadl.imp/relationship" alias rel.

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl/src/com/ge/research/sadl/model/DeclarationExtensions.xtend
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl/src/com/ge/research/sadl/model/DeclarationExtensions.xtend
@@ -289,6 +289,9 @@ class DeclarationExtensions {
 				SadlProperty case e.restrictions.filter(SadlRangeRestriction).exists[!range.isDatatype]: 
 					OntConceptType.CLASS_PROPERTY
 
+				SadlProperty case e.hasFromToRestriction:
+					e.inferrConceptTypeFromToType
+
 				SadlProperty: 
 					OntConceptType.RDF_PROPERTY
 					
@@ -322,6 +325,31 @@ class DeclarationExtensions {
 		} finally {
 			recursionDetection.get.remove(resource)
 		}
+	}
+	
+	/**
+	 * Returns with the SADL resource of the `TO` of the given SADL property argument.
+	 * Returns {@code null} if the argument is {@code null}, if any of the {@code from} or 
+	 * {@code to} type references are not given. Also provides a {@code null} return value
+	 * if the {@code to} is not a type of the simple SADL type reference. 
+	 */
+	private def SadlResource getToType(SadlProperty it) {
+		if (it !== null && from !== null && to instanceof SadlSimpleTypeReference) {
+			return (to as SadlSimpleTypeReference).type as SadlResource;
+		}
+		return null;
+	}
+	
+	private def boolean hasFromToRestriction(SadlProperty it) {
+		return null !== toType;
+	}
+	
+	private def OntConceptType inferrConceptTypeFromToType(SadlProperty it) {
+		return switch (toType.ontConceptType) {
+			case CLASS: OntConceptType.CLASS_PROPERTY
+			case DATATYPE: OntConceptType.DATATYPE_PROPERTY
+			default: OntConceptType.RDF_PROPERTY
+		}		
 	}
 	
 	def Iterable<? extends SadlResource> getReferencedSadlResources(SadlTypeReference typeRef) {


### PR DESCRIPTION
When no range restrictions are available, then this required information
is inferred from the `to` type of the property.

Closes #168.
Task: #168.

Signed-off-by: Akos Kitta <kittaakos@gmail.com>