### PR TITLE
Added range restriction text user data to the EObject description.

### DIFF
--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui.tests/src/com/ge/research/sadl/ui/tests/AbstractSadlBuilderTest.xtend
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui.tests/src/com/ge/research/sadl/ui/tests/AbstractSadlBuilderTest.xtend
@@ -1,0 +1,46 @@
+/************************************************************************
+ * Copyright © 2007-2017 - General Electric Company, All Rights Reserved
+ * 
+ * Project: SADL
+ * 
+ * Description: The Semantic Application Design Language (SADL) is a
+ * language for building semantic models and expressing rules that
+ * capture additional domain knowledge. The SADL-IDE (integrated
+ * development environment) is a set of Eclipse plug-ins that
+ * support the editing and testing of semantic models using the
+ * SADL language.
+ * 
+ * This software is distributed "AS-IS" without ANY WARRANTIES
+ * and licensed under the Eclipse Public License - v 1.0
+ * which is available at http://www.eclipse.org/org/documents/epl-v10.php
+ * 
+ ***********************************************************************/
+package com.ge.research.sadl.ui.tests
+
+import org.eclipse.core.resources.IResource
+
+import static org.eclipse.core.resources.IMarker.*
+import static org.eclipse.core.resources.IResource.*
+
+/**
+ * Base for all platform and or builder related tests.
+ * 
+ * @author akos.kitta
+ */
+abstract class AbstractSadlBuilderTest extends AbstractSadlPlatformTest {
+	
+	/**
+	 * Asserts that the given resource has at least one associated problem marker with error severity. 
+	 */
+	protected def assertHasErrors(IResource resource) {
+		assertEquals(SEVERITY_ERROR, resource.findMaxProblemSeverity(PROBLEM, true, DEPTH_INFINITE));
+	}
+	
+	/**
+	 * Asserts that the given resource has zero problems markers with either error or warning severity.
+	 */
+	protected def assertHasNoIssues(IResource resource) {
+		assertEquals(/*No errors/warnings.*/ -1, resource.findMaxProblemSeverity(PROBLEM, true, DEPTH_INFINITE));
+	}
+	
+}

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl/src/com/ge/research/sadl/resource/UserDataHelper.xtend
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl/src/com/ge/research/sadl/resource/UserDataHelper.xtend
@@ -1,29 +1,33 @@
 /************************************************************************
  * Copyright © 2007-2016 - General Electric Company, All Rights Reserved
- *
+ * 
  * Project: SADL
- *
+ * 
  * Description: The Semantic Application Design Language (SADL) is a
  * language for building semantic models and expressing rules that
  * capture additional domain knowledge. The SADL-IDE (integrated
  * development environment) is a set of Eclipse plug-ins that
  * support the editing and testing of semantic models using the
  * SADL language.
- *
+ * 
  * This software is distributed "AS-IS" without ANY WARRANTIES
  * and licensed under the Eclipse Public License - v 1.0
  * which is available at http://www.eclipse.org/org/documents/epl-v10.php
- *
+ * 
  ***********************************************************************/
 package com.ge.research.sadl.resource
 
 import com.ge.research.sadl.sADL.SadlModel
+import com.ge.research.sadl.sADL.SadlProperty
+import com.ge.research.sadl.sADL.SadlResource
 import com.google.common.base.Optional
 import com.google.common.collect.ImmutableMap
 import com.google.inject.Singleton
 import java.util.Collections
 import java.util.Map
+import org.eclipse.emf.ecore.EClass
 import org.eclipse.emf.ecore.EObject
+import org.eclipse.xtext.nodemodel.util.NodeModelUtils
 import org.eclipse.xtext.resource.IEObjectDescription
 
 import static com.ge.research.sadl.sADL.SADLPackage.Literals.*
@@ -37,8 +41,28 @@ import static com.ge.research.sadl.sADL.SADLPackage.Literals.*
 class UserDataHelper {
 
 	public static val USER_DATA_ALIAS = 'alias';
+	public static val USER_DATE_PROPERTY_RESTRICTION = 'property_restriction';
 
 	def dispatch Map<String, String> createUserData(EObject it) {
+		return Collections.emptyMap;
+	}
+
+	def dispatch Map<String, String> createUserData(SadlResource it) {
+		if (eContainer instanceof SadlProperty) {
+			return (eContainer as SadlProperty).createUserData;
+		}
+		return Collections.emptyMap;
+	}
+
+	def dispatch Map<String, String> createUserData(SadlProperty it) {
+		val node = NodeModelUtils.findActualNodeFor(it);
+		if (node !== null && !node.text.nullOrEmpty) {
+			val rawText = node.text
+			// Replace all non-single whitespaces and EOL with a single space, so that when the user
+			// performs any whitespce changes, the underlying EObjectDescription will be marked as unchanged. 
+			val text = rawText.trim.replaceAll("\r?\n", " ").replaceAll(" +", " ");
+			return Collections.singletonMap(USER_DATE_PROPERTY_RESTRICTION, text);
+		}
 		return Collections.emptyMap;
 	}
 
@@ -51,14 +75,22 @@ class UserDataHelper {
 	}
 
 	def Optional<String> getAlias(IEObjectDescription it) {
-		return getSadlModelData(USER_DATA_ALIAS);
+		return getUserData(USER_DATA_ALIAS, SADL_MODEL);
 	}
 
-	private def Optional<String> getSadlModelData(IEObjectDescription desc, String key) {
-		if (SADL_MODEL === desc.EClass) {
-			return Optional.fromNullable(desc.getUserData(key));
+	def Optional<String> getPropertyRestriction(IEObjectDescription it) {
+		return getUserData(USER_DATE_PROPERTY_RESTRICTION, null);
+	}
+
+	/**
+	 * Tries to extract a desired given user object from the EObject description. EClass argument is just a minor performance tweak.
+	 * If you would like to avoid that predicate evaluation, pass in {@code null}.
+	 */
+	private def Optional<String> getUserData(IEObjectDescription desc, String key, /*nullable*/ EClass expectedClass) {
+		if (expectedClass !== null && expectedClass !== desc.EClass) {
+			return Optional.absent;
 		}
-		return Optional.absent;
+		return Optional.fromNullable(desc.getUserData(key));
 	}
 
 }


### PR DESCRIPTION
This PR includes some naive logic that helps the incremental builder to rebuild downstream dependencies too.

For instance, changing the type of a property did not cause the resource to get rebuilt.

This PR <b>is</b> the precondition of https://github.com/GEGlobalResearch/requirements/pull/51.

This was required to mark a resource description as a changed one even
if the SADL resources do not change but their type or restriction had.

Signed-off-by: Akos Kitta <kittaakos@gmail.com>