### PR TITLE
GH-286: Implemented custom hover provider for SADL resources.

### DIFF
--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.tests/src/com/ge/research/sadl/tests/SadlResourceCommentProviderTest.xtend
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.tests/src/com/ge/research/sadl/tests/SadlResourceCommentProviderTest.xtend
@@ -1,0 +1,119 @@
+/************************************************************************
+ * Copyright 2007-2018 General Electric Company, All Rights Reserved
+ * 
+ * Project: SADL
+ * 
+ * Description: The Semantic Application Design Language (SADL) is a
+ * language for building semantic models and expressing rules that
+ * capture additional domain knowledge. The SADL-IDE (integrated
+ * development environment) is a set of Eclipse plug-ins that
+ * support the editing and testing of semantic models using the
+ * SADL language.
+ * 
+ * This software is distributed "AS-IS" without ANY WARRANTIES
+ * and licensed under the Eclipse Public License - v 1.0
+ * which is available at http://www.eclipse.org/org/documents/epl-v10.php
+ * 
+ ***********************************************************************/
+package com.ge.research.sadl.tests
+
+import com.ge.research.sadl.sADL.SadlResource
+import com.ge.research.sadl.utils.SadlResourceCommentProvider
+import com.google.common.collect.Iterables
+import com.google.inject.Inject
+import org.eclipse.xtext.EcoreUtil2
+import org.eclipse.xtext.resource.XtextResource
+import org.junit.Assert
+import org.junit.Test
+
+import static extension com.ge.research.sadl.tests.helpers.XtendTemplateHelper.unifyEOL
+
+class SadlResourceCommentProviderTest extends AbstractSadlTest {
+
+	@Inject
+	private SadlResourceCommentProvider commentProvider;
+
+	@Test
+	def void testComments_noAnnotations() {
+		'''
+			uri "http://sadl.org/a.sadl".
+			AllThingsGood is a class.
+		'''.assertComments(#[]);
+	}
+
+	@Test
+	def void testComments_singleAlias() {
+		'''
+			uri "http://sadl.org/a.sadl".
+			AllThingsGood (alias "first alias") is a class.
+		'''.assertComments(#[]);
+	}
+
+	@Test
+	def void testComments_multipleAliases() {
+		'''
+			uri "http://sadl.org/a.sadl".
+			AllThingsGood (alias "first alias", "second alias", "third alias") is a class.
+		'''.assertComments(#[]);
+	}
+
+	@Test
+	def void testComments_singleComment() {
+		'''
+			uri "http://sadl.org/a.sadl".
+			AllThingsGood (note "first comment") is a class.
+		'''.assertComments(#['first comment']);
+	}
+
+	@Test
+	def void testComments_multipleComments() {
+		'''
+			uri "http://sadl.org/a.sadl".
+			AllThingsGood (note "first comment", "second comment", "third comment") is a class.
+		'''.assertComments(#['first comment', 'second comment', 'third comment']);
+	}
+
+	@Test
+	def void testComments_singleComment_LB() {
+		'''
+			uri "http://sadl.org/a.sadl".
+			AllThingsGood (note "first
+comment") is a class.
+		'''.assertComments(#['first
+comment']);
+	}
+
+	@Test
+	def void testComments_multipleComments_LB() {
+		'''
+			uri "http://sadl.org/a.sadl".
+			AllThingsGood (note "first 
+comment", "second
+comment", "third
+
+comment") is a class.
+		'''.assertComments(#['first 
+comment', 'second
+comment', 'third
+
+comment']);
+	}
+
+	protected def dispatch void assertComments(CharSequence model, Iterable<String> expected) {
+		assertComments(model.sadl, expected);
+	}
+
+	protected def dispatch void assertComments(XtextResource model, Iterable<String> expected) {
+		EcoreUtil2.getAllContentsOfType(model.sadlModel, SadlResource).head.assertComments(expected);
+	}
+
+	protected def dispatch void assertComments(SadlResource it, Iterable<String> expected) {
+		val actual = commentProvider.getComment(it).map[unifyEOL].toList;
+		Assert.assertEquals(
+			'''Expected: «Iterables.toString(expected)». Got instead: «Iterables.toString(actual)»''',
+			expected.map[unifyEOL].toList,
+			actual
+		);
+	}
+
+}

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui/src/com/ge/research/sadl/ui/SADLUiModule.xtend
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui/src/com/ge/research/sadl/ui/SADLUiModule.xtend
@@ -29,6 +29,8 @@ import com.ge.research.sadl.ui.editor.AlwaysAddXtextNatureCallback
 import com.ge.research.sadl.ui.editor.SadlCopyQualifiedNameService
 import com.ge.research.sadl.ui.editor.SadlProblemAnnotationHover
 import com.ge.research.sadl.ui.generator.SadlShouldGenerate
+import com.ge.research.sadl.ui.hover.SadlEObjectDocumentationProvider
+import com.ge.research.sadl.ui.hover.SadlEObjectHoverProvider
 import com.ge.research.sadl.ui.markers.EclipseMarkerSeverityMapper
 import com.ge.research.sadl.ui.preferences.SadlPreferenceStoreAccess
 import com.ge.research.sadl.ui.preferences.SadlPreferencesInitializer
@@ -39,12 +41,14 @@ import com.ge.research.sadl.ui.syntaxcoloring.SadlTokenToAttributeIdMapper
 import com.google.inject.Binder
 import com.google.inject.name.Names
 import org.eclipse.ui.plugin.AbstractUIPlugin
+import org.eclipse.xtext.documentation.IEObjectDocumentationProvider
 import org.eclipse.xtext.generator.IShouldGenerate
 import org.eclipse.xtext.ide.editor.contentassist.antlr.ContentAssistContextFactory
 import org.eclipse.xtext.ide.editor.syntaxcoloring.AbstractAntlrTokenToAttributeIdMapper
 import org.eclipse.xtext.ide.editor.syntaxcoloring.ISemanticHighlightingCalculator
 import org.eclipse.xtext.ui.editor.contentassist.AbstractJavaBasedContentProposalProvider.ReferenceProposalCreator
 import org.eclipse.xtext.ui.editor.copyqualifiedname.CopyQualifiedNameService
+import org.eclipse.xtext.ui.editor.hover.IEObjectHoverProvider
 import org.eclipse.xtext.ui.editor.preferences.IPreferenceStoreAccess
 import org.eclipse.xtext.ui.editor.preferences.IPreferenceStoreInitializer
 import org.eclipse.xtext.ui.editor.preferences.LanguageRootPreferencePage
@@ -71,7 +75,7 @@ class SADLUiModule extends AbstractSADLUiModule {
 
 	// Maps our Ecore nodes to our syntax coloring styles.
 	def Class<? extends ISemanticHighlightingCalculator> bindISemanticHighlightingCalculator() {
-		return SadlSemanticHighlightingCalculator
+		return SadlSemanticHighlightingCalculator	
 	}
 
 	// Maps our token names to our syntax coloring styles.
@@ -126,6 +130,14 @@ class SADLUiModule extends AbstractSADLUiModule {
 	
 	override bindIAnnotationHover() {
 		return SadlProblemAnnotationHover;
+	}
+	
+	def Class<? extends IEObjectHoverProvider> bindIEObjectHoverProvider() {
+		return SadlEObjectHoverProvider;
+	}
+	
+	def Class<? extends IEObjectDocumentationProvider> bindIEObjectDocumentationProvider() {
+		return SadlEObjectDocumentationProvider;
 	}
 	
 }

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui/src/com/ge/research/sadl/ui/hover/SadlEObjectDocumentationProvider.xtend
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui/src/com/ge/research/sadl/ui/hover/SadlEObjectDocumentationProvider.xtend
@@ -1,0 +1,46 @@
+/************************************************************************
+ * Copyright © 2007-2018 - General Electric Company, All Rights Reserved
+ * 
+ * Project: SADL
+ * 
+ * Description: The Semantic Application Design Language (SADL) is a
+ * language for building semantic models and expressing rules that
+ * capture additional domain knowledge. The SADL-IDE (integrated
+ * development environment) is a set of Eclipse plug-ins that
+ * support the editing and testing of semantic models using the
+ * SADL language.
+ * 
+ * This software is distributed "AS-IS" without ANY WARRANTIES
+ * and licensed under the Eclipse Public License - v 1.0
+ * which is available at http://www.eclipse.org/org/documents/epl-v10.php
+ * 
+ ***********************************************************************/
+package com.ge.research.sadl.ui.hover
+
+import com.ge.research.sadl.sADL.SadlResource
+import com.ge.research.sadl.utils.SadlResourceCommentProvider
+import com.google.inject.Inject
+import org.eclipse.emf.ecore.EObject
+import org.eclipse.xtext.documentation.IEObjectDocumentationProvider
+
+/**
+ * EObject documentation provider for showing an arbitrary documentation for a particular AST node element.
+ * 
+ * @author akos.kitta
+ */
+class SadlEObjectDocumentationProvider implements IEObjectDocumentationProvider {
+
+	@Inject
+	extension SadlResourceCommentProvider
+
+	override getDocumentation(EObject it) {
+		if (it instanceof SadlResource) {
+			val comments = comment;
+			if (!comments.nullOrEmpty) {
+				return comments.map['''<p>«it.replaceAll('\r?\n', '<br>')»</p>'''].join('');	
+			}
+		}
+		return null;
+	}
+
+}

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui/src/com/ge/research/sadl/ui/hover/SadlEObjectHoverProvider.xtend
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui/src/com/ge/research/sadl/ui/hover/SadlEObjectHoverProvider.xtend
@@ -1,0 +1,50 @@
+/************************************************************************
+ * Copyright © 2007-2018 - General Electric Company, All Rights Reserved
+ * 
+ * Project: SADL
+ * 
+ * Description: The Semantic Application Design Language (SADL) is a
+ * language for building semantic models and expressing rules that
+ * capture additional domain knowledge. The SADL-IDE (integrated
+ * development environment) is a set of Eclipse plug-ins that
+ * support the editing and testing of semantic models using the
+ * SADL language.
+ * 
+ * This software is distributed "AS-IS" without ANY WARRANTIES
+ * and licensed under the Eclipse Public License - v 1.0
+ * which is available at http://www.eclipse.org/org/documents/epl-v10.php
+ * 
+ ***********************************************************************/
+package com.ge.research.sadl.ui.hover
+
+import com.ge.research.sadl.model.DeclarationExtensions
+import com.ge.research.sadl.sADL.SadlResource
+import com.ge.research.sadl.utils.SadlResourceCommentProvider
+import com.google.inject.Inject
+import org.eclipse.emf.ecore.EObject
+import org.eclipse.xtext.ui.editor.hover.html.DefaultEObjectHoverProvider
+
+/**
+ * Hover provider for showing additional SADL resource related information in a pop-up dialog
+ * when hovering over a SADL resource in the editor.
+ * 
+ * @author akos.kitta
+ */
+class SadlEObjectHoverProvider extends DefaultEObjectHoverProvider {
+
+	@Inject
+	extension DeclarationExtensions;
+
+	@Inject
+	extension SadlResourceCommentProvider;
+
+	override protected getFirstLine(EObject it) {
+		if (it instanceof SadlResource) {
+			if (!comment.nullOrEmpty) {
+				return '''SADL resource: <i>«concreteName»</i>.''';
+			}
+		}
+		return super.getFirstLine(it);
+	}
+
+}

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl/src/com/ge/research/sadl/utils/SadlResourceCommentProvider.xtend
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl/src/com/ge/research/sadl/utils/SadlResourceCommentProvider.xtend
@@ -1,0 +1,49 @@
+/************************************************************************
+ * Copyright 2007-2018 General Electric Company, All Rights Reserved
+ * 
+ * Project: SADL
+ * 
+ * Description: The Semantic Application Design Language (SADL) is a
+ * language for building semantic models and expressing rules that
+ * capture additional domain knowledge. The SADL-IDE (integrated
+ * development environment) is a set of Eclipse plug-ins that
+ * support the editing and testing of semantic models using the
+ * SADL language.
+ * 
+ * This software is distributed "AS-IS" without ANY WARRANTIES
+ * and licensed under the Eclipse Public License - v 1.0
+ * which is available at http://www.eclipse.org/org/documents/epl-v10.php
+ * 
+ ***********************************************************************/
+package com.ge.research.sadl.utils
+
+import com.ge.research.sadl.sADL.SadlResource
+import com.google.inject.ImplementedBy
+
+/**
+ * Provides RDF comments for SADL resources.
+ * 
+ * @author akos.kitta 
+ */
+@ImplementedBy(Default)
+interface SadlResourceCommentProvider {
+
+	/**
+	 * Returns with the comment extracted from the {@code note} annotation from the given SADL resource.
+	 * Returns with an empty iterable if no comments are attached to the SADL resource argument.
+	 */
+	def Iterable<String> getComment(SadlResource it);
+
+}
+
+
+/**
+ * The default comments provider.
+ */
+class Default implements SadlResourceCommentProvider {
+
+	override getComment(SadlResource it) {
+		return it.annotations.filter[type == 'note'].map[contents].flatten;
+	}
+
+}


### PR DESCRIPTION
When a SADL resource has one or more `note` annotation attached to
it, it will be shown in the pop-up dialog on hover. Keeps the LB.

Closes #286.

![gh-286](https://user-images.githubusercontent.com/1405703/37591768-dd1c3810-2b6c-11e8-931d-090420822bbc.gif)

Signed-off-by: Akos Kitta <kittaakos@gmail.com>