### PR TITLE
GH-341: Made the CA more robust.

### DIFF
--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ide/src/com/ge/research/sadl/ide/editor/contentassist/SadlOntologyContextProvider.xtend
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ide/src/com/ge/research/sadl/ide/editor/contentassist/SadlOntologyContextProvider.xtend
@@ -232,6 +232,12 @@ class SadlOntologyContextProvider implements IOntologyContextProvider {
 		return OntModelProvider.find(eResource);
 	}
 
+	//--------------getPropertyInitializer--------------------------
+
+	private def dispatch getPropertyInitializer(EObject it) {
+		return null;
+	}
+
 	private def dispatch getPropertyInitializer(SadlModel it) {
 		val spi = EcoreUtil2.getAllContentsOfType(it, SadlPropertyInitializer)
 		if (!spi.empty) {
@@ -241,21 +247,27 @@ class SadlOntologyContextProvider implements IOntologyContextProvider {
 		if (!spsr.empty) {
 			return (spsr as List<SadlResource>).head;
 		}
-		return null
+		return null;
 	}
-	
+
 	private def dispatch getPropertyInitializer(SadlSimpleTypeReference it) {
-		return it
+		return it;
 	}
 
 	private def dispatch getPropertyInitializer(SadlPropertyInitializer it) {
 		return it;
 	}
-	
+
+	//--------------getClassOrPropertyInitializer--------------------------
+
+	private def dispatch getClassOrPropertyInitializer(EObject it) {
+		return null;
+	}
+
 	private def dispatch getClassOrPropertyInitializer(SadlInstance it) {
 		return it;
-	} 
-	
+	}
+
 	private def dispatch getClassOrPropertyInitializer(SadlSimpleTypeReference it) {
 		return it;
 	}
@@ -267,13 +279,19 @@ class SadlOntologyContextProvider implements IOntologyContextProvider {
 	private def dispatch getClassOrPropertyInitializer(SadlRangeRestriction it) {
 		return it;
 	}
-	
+
 	private def dispatch getClassOrPropertyInitializer(BinaryOperation it) {
 		return it;
 	}
 
 	private def dispatch getClassOrPropertyInitializer(SadlModel it) {
 		return EcoreUtil2.getAllContentsOfType(it, SadlClassOrPropertyDeclaration).head;
+	}
+
+	//--------------getPropOfSubjectInitializer--------------------------
+
+	private def dispatch getPropOfSubjectInitializer(EObject it) {
+		return null;
 	}
 
 	private def dispatch getPropOfSubjectInitializer(PropOfSubject it) {
@@ -284,6 +302,12 @@ class SadlOntologyContextProvider implements IOntologyContextProvider {
 		return EcoreUtil2.getAllContentsOfType(it, PropOfSubject).head;
 	}
 
+	//--------------getSubjHasPropInitializer--------------------------
+
+	protected def dispatch getSubjHasPropInitializer(EObject it) {
+		return null;
+	}
+
 	protected def dispatch getSubjHasPropInitializer(SubjHasProp it) {
 		return it;
 	}
@@ -291,8 +315,9 @@ class SadlOntologyContextProvider implements IOntologyContextProvider {
 	protected def dispatch getSubjHasPropInitializer(SadlModel it) {
 		return EcoreUtil2.getAllContentsOfType(it, SubjHasProp).head;
 	}
-	
+
 	protected def dispatch getSubjHasPropInitializer(QueryStatement it) {
 		return EcoreUtil2.getAllContentsOfType(it, SubjHasProp).head;
 	}
+
 }

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl/src/com/ge/research/sadl/processing/ISadlOntologyHelper.xtend
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl/src/com/ge/research/sadl/processing/ISadlOntologyHelper.xtend
@@ -246,7 +246,9 @@ interface ISadlOntologyHelper {
 		}
 
 		def Context build() {
-			Preconditions.checkNotNull(ontModel, 'ontModel');
+			if (ontModel === null) {
+				return null;
+			}
 			return new ContextImpl(ontModel, subject, modelProcessor, acceptor, grammarContextId, contextClass, restrictions);
 		}
 

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl/src/com/ge/research/sadl/scoping/SADLScopeProvider.xtend
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl/src/com/ge/research/sadl/scoping/SADLScopeProvider.xtend
@@ -352,23 +352,29 @@ class SADLScopeProvider extends AbstractGlobalScopeDelegatingScopeProvider {
 						SadlResource case concreteName !== null: {
 							handleSadlResource(context);
 						}
+						// if (!it.name.concreteName.nullOrEmpty) as a workaround for the broken AST
+						// E.g.: `Equation Equation Equation Equation <|>newtons2ndLaw`
 						EquationStatement: {
-							val name = converter.toQualifiedName(it.name.concreteName)
-							map.addElement(name, it.name)
-							if (name.segmentCount > 1) {
-								map.addElement(name.skipFirst(1), it.name)
-							} else if (namespace !== null) {
-								map.addElement(namespace.append(name), it.name)
+							if (!it.name.concreteName.nullOrEmpty) {
+								val name = converter.toQualifiedName(it.name.concreteName)
+								map.addElement(name, it.name)
+								if (name.segmentCount > 1) {
+									map.addElement(name.skipFirst(1), it.name)
+								} else if (namespace !== null) {
+									map.addElement(namespace.append(name), it.name)
+								}
 							}
 							iter.prune
 						}
 						ExternalEquationStatement: {
-							val name = converter.toQualifiedName(it.name.concreteName)
-							map.addElement(name, it.name)
-							if (name.segmentCount > 1) {
-								map.addElement(name.skipFirst(1), it.name)
-							} else if (namespace !== null) {
-								map.addElement(namespace.append(name), it.name)
+							if (!it.name.concreteName.nullOrEmpty) {
+								val name = converter.toQualifiedName(it.name.concreteName)
+								map.addElement(name, it.name)
+								if (name.segmentCount > 1) {
+									map.addElement(name.skipFirst(1), it.name)
+								} else if (namespace !== null) {
+									map.addElement(namespace.append(name), it.name)
+								}
 							}
 							iter.prune
 						}


### PR DESCRIPTION
Added the default dispatch methods with `EObject` type,
so that the CA will not throw an `IAE: Unhandled parameter types`

Closes: #341.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>