### PR TITLE
GH-345: Added a workaround for the preference pages.

### DIFF
--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui/src/com/ge/research/sadl/ui/preferences/FieldEditorExtensions.xtend
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui/src/com/ge/research/sadl/ui/preferences/FieldEditorExtensions.xtend
@@ -1,0 +1,119 @@
+/************************************************************************
+ * Copyright © 2007-2018 - General Electric Company, All Rights Reserved
+ * 
+ * Project: SADL
+ * 
+ * Description: The Semantic Application Design Language (SADL) is a
+ * language for building semantic models and expressing rules that
+ * capture additional domain knowledge. The SADL-IDE (integrated
+ * development environment) is a set of Eclipse plug-ins that
+ * support the editing and testing of semantic models using the
+ * SADL language.
+ * 
+ * This software is distributed "AS-IS" without ANY WARRANTIES
+ * and licensed under the Eclipse Public License - v 1.0
+ * which is available at http://www.eclipse.org/org/documents/epl-v10.php
+ * 
+ ***********************************************************************/
+package com.ge.research.sadl.ui.preferences
+
+import org.eclipse.jface.preference.BooleanFieldEditor
+import org.eclipse.jface.preference.FileFieldEditor
+import org.eclipse.jface.preference.RadioGroupFieldEditor
+import org.eclipse.jface.preference.StringFieldEditor
+import org.eclipse.swt.widgets.Composite
+import org.eclipse.xtend.lib.annotations.Accessors
+
+/**
+ * This class provides a workaround for the following issues:
+ * <ul>
+ * <li>https://github.com/eclipse/xtext-eclipse/issues/238</li>
+ * <li>https://github.com/eclipse/xtext-eclipse/issues/916</li>
+ * </ul>
+ */
+final class FieldEditorExtensions {
+
+	static interface FieldEditorExt {
+		def Composite getParent();
+	}
+
+	static class StringFieldEditorExt extends StringFieldEditor implements FieldEditorExt {
+
+		@Accessors(PUBLIC_GETTER)
+		val Composite parent
+
+		new(String name, String labelText, Composite parent) {
+			super(name, labelText, parent);
+			this.parent = parent;
+		}
+
+		override protected doStore() {
+			preferenceStore.putValue(preferenceName, textControl.text);
+		}
+
+	}
+
+	static class FileFieldEditorExt extends FileFieldEditor implements FieldEditorExt {
+
+		@Accessors(PUBLIC_GETTER)
+		val Composite parent
+
+		new(String name, String labelText, Composite parent) {
+			super(name, labelText, parent);
+			this.parent = parent;
+		}
+
+		override protected doStore() {
+			preferenceStore.putValue(preferenceName, textControl.text);
+		}
+
+		override getNumberOfControls() {
+			return 1;
+		}
+
+		override void doFillIntoGrid(Composite parent, int numColumns) {
+			super.doFillIntoGrid(parent, 1);
+		}
+
+	}
+
+	static class BooleanFieldEditorExt extends BooleanFieldEditor implements FieldEditorExt {
+
+		@Accessors(PUBLIC_GETTER)
+		val Composite parent
+
+		new(String name, String labelText, Composite parent) {
+			super(name, labelText, parent);
+			this.parent = parent;
+		}
+
+		override protected doStore() {
+			preferenceStore.putValue(preferenceName, Boolean.toString(booleanValue));
+		}
+
+	}
+
+	static class RadioGroupFieldEditorExt extends RadioGroupFieldEditor implements FieldEditorExt {
+
+		@Accessors(PUBLIC_GETTER)
+		val Composite parent
+
+		new(String name, String labelText, int numColumns, String[][] labelAndValues, Composite parent) {
+			super(name, labelText, numColumns, labelAndValues, parent, false);
+			this.parent = parent;
+		}
+
+		override protected doStore() {
+			val field = RadioGroupFieldEditor.getDeclaredField('value');
+			field.accessible = true;
+			val value = field.get(this);
+			if (value instanceof String) {
+				preferenceStore.putValue(preferenceName, value);
+			} else {
+				preferenceStore.toDefault = preferenceName;
+			}
+		}
+
+	}
+
+}

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui/src/com/ge/research/sadl/ui/preferences/SadlRootPreferencePage.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui/src/com/ge/research/sadl/ui/preferences/SadlRootPreferencePage.java
@@ -17,17 +17,50 @@
  ***********************************************************************/
 package com.ge.research.sadl.ui.preferences;
 
-import java.lang.reflect.Field;
+import static com.ge.research.sadl.preferences.SadlPreferences.CHECK_FOR_AMBIGUOUS_NAMES;
+import static com.ge.research.sadl.preferences.SadlPreferences.CHECK_FOR_CARDINALITY_OF_PROPERTY_IN_DOMAIN;
+import static com.ge.research.sadl.preferences.SadlPreferences.CREATE_DOMAIN_AND_RANGE_AS_UNION_CLASSES;
+import static com.ge.research.sadl.preferences.SadlPreferences.DEEP_VALIDATION_OFF;
+import static com.ge.research.sadl.preferences.SadlPreferences.DMY_ORDER_DMY;
+import static com.ge.research.sadl.preferences.SadlPreferences.DMY_ORDER_MDY;
+import static com.ge.research.sadl.preferences.SadlPreferences.GENERATE_METRICS_REPORT_ON_CLEAN_BUILD;
+import static com.ge.research.sadl.preferences.SadlPreferences.GRAPH_IMPLICIT_ELEMENTS;
+import static com.ge.research.sadl.preferences.SadlPreferences.GRAPH_IMPLICIT_ELEMENT_INSTANCES;
+import static com.ge.research.sadl.preferences.SadlPreferences.GRAPH_RENDERER_CLASS;
+import static com.ge.research.sadl.preferences.SadlPreferences.IGNORE_UNITTEDQUANTITIES;
+import static com.ge.research.sadl.preferences.SadlPreferences.JENA_TDB;
+import static com.ge.research.sadl.preferences.SadlPreferences.METRICS_QUERY_FILENAME;
+import static com.ge.research.sadl.preferences.SadlPreferences.MODEL_NAMESPACES;
+import static com.ge.research.sadl.preferences.SadlPreferences.N3_FORMAT;
+import static com.ge.research.sadl.preferences.SadlPreferences.NAMESPACE_IN_QUERY_RESULTS;
+import static com.ge.research.sadl.preferences.SadlPreferences.N_TRIPLE_FORMAT;
+import static com.ge.research.sadl.preferences.SadlPreferences.OWL_MODEL_FORMAT;
+import static com.ge.research.sadl.preferences.SadlPreferences.PREFIXES_ONLY_AS_NEEDED;
+import static com.ge.research.sadl.preferences.SadlPreferences.P_USE_ARTICLES_IN_VALIDATION;
+import static com.ge.research.sadl.preferences.SadlPreferences.RDF_XML_ABBREV_FORMAT;
+import static com.ge.research.sadl.preferences.SadlPreferences.RDF_XML_FORMAT;
+import static com.ge.research.sadl.preferences.SadlPreferences.SADL_BASE_URI;
+import static com.ge.research.sadl.preferences.SadlPreferences.SADL_FILE_NAMES;
+import static com.ge.research.sadl.preferences.SadlPreferences.SHOW_TIMING_INFORMATION;
+import static com.ge.research.sadl.preferences.SadlPreferences.TABULAR_DATA_IMPORTER_CLASS;
+import static com.ge.research.sadl.preferences.SadlPreferences.TYPE_CHECKING_RANGE_REQUIRED;
+import static com.ge.research.sadl.preferences.SadlPreferences.TYPE_CHECKING_WARNING_ONLY;
+import static com.ge.research.sadl.preferences.SadlPreferences.VALIDATE_BEFORE_TEST;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.preferences.IPreferencesService;
-import org.eclipse.jface.preference.BooleanFieldEditor;
-import org.eclipse.jface.preference.FileFieldEditor;
+import org.eclipse.jface.preference.FieldEditor;
 import org.eclipse.jface.preference.IPreferenceStore;
-import org.eclipse.jface.preference.RadioGroupFieldEditor;
-import org.eclipse.jface.preference.StringFieldEditor;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.xtext.ui.editor.preferences.LanguageRootPreferencePage;
 
@@ -36,276 +69,149 @@ import com.ge.research.sadl.reasoner.ConfigurationItem;
 import com.ge.research.sadl.reasoner.ConfigurationItem.NameValuePair;
 import com.ge.research.sadl.reasoner.ConfigurationManager;
 import com.ge.research.sadl.reasoner.IConfigurationManager;
+import com.ge.research.sadl.ui.preferences.FieldEditorExtensions.BooleanFieldEditorExt;
+import com.ge.research.sadl.ui.preferences.FieldEditorExtensions.FieldEditorExt;
+import com.ge.research.sadl.ui.preferences.FieldEditorExtensions.FileFieldEditorExt;
+import com.ge.research.sadl.ui.preferences.FieldEditorExtensions.RadioGroupFieldEditorExt;
+import com.ge.research.sadl.ui.preferences.FieldEditorExtensions.StringFieldEditorExt;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.Lists;
 
+@SuppressWarnings("restriction")
 public class SadlRootPreferencePage extends LanguageRootPreferencePage {
+
+	/**
+	 * You can iterate on this, but <b>DO NOT</b> modify it!</br>
+	 * It is a hack for https://github.com/eclipse/xtext-eclipse/issues/916.
+	 */
+	protected List<FieldEditor> editorsCopy = Lists.newArrayList();
+
+	@Override
+	public void dispose() {
+		super.dispose();
+		editorsCopy.clear();
+	}
+
+	@Override
+	protected void addField(FieldEditor editor) {
+		super.addField(editor);
+		// We have to save our copy of the field editors.
+		// Otherwise, we cannot perform a custom `updateFieldEditors(boolean)`.
+		// `editors` is private in the super class.
+		this.editorsCopy.add(editor);
+	}
 	
-	@SuppressWarnings("restriction")
+	@Override
+	protected void adjustGridLayout() {
+		Iterable<FieldEditorExt> fieldExts = FluentIterable.from(editorsCopy).filter(FieldEditorExt.class);
+		Map<Composite, List<FieldEditorExt>> editorsPerGroup = StreamSupport.stream(fieldExts.spliterator(), false).collect(Collectors.groupingBy(FieldEditorExt::getParent));
+		for (Composite group : editorsPerGroup.keySet()) {
+			List<FieldEditorExt> editors = editorsPerGroup.get(group);
+			int max = 0;
+			if (editors != null) {
+				for (FieldEditorExt editor : editors) {
+					if (editor instanceof FieldEditor) {
+						int numberOfControls = ((FieldEditor) editor).getNumberOfControls();
+						if (numberOfControls > max) {
+							max = numberOfControls;
+						}
+					}
+				}
+			}
+			group.setLayout(new GridLayout(Math.max(max - 1, 1), false));
+		}
+	}
+
+	@Override
+	protected void updateFieldEditors(boolean enabled) {
+		Composite parent = getFieldEditorParent();
+		for (FieldEditor editor : editorsCopy) {
+			editor.load();
+			if (editor instanceof FieldEditorExt) {
+				editor.setEnabled(enabled, ((FieldEditorExt) editor).getParent());
+			} else {
+				editor.setEnabled(enabled, parent);
+			}
+		}
+		Button defaultsButton = getDefaultsButton();
+		if (defaultsButton != null) {
+			defaultsButton.setEnabled(enabled);
+		}
+	}
+
+	protected Composite createSettingsGroup(Composite parent, int styles, String text) {
+		Group group = new Group(parent, styles);
+		group.setLayout(new GridLayout(1, false)); // We will adjust the columns later.
+		group.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+		group.setText(text);
+		return group;
+	}
+
 	@Override
 	protected void createFieldEditors() {
 		// General SADL Settings
-		Group generalSettings = new Group(getFieldEditorParent(), SWT.NONE);
-		generalSettings.setLayout(new FillLayout(SWT.HORIZONTAL));
-		generalSettings.setText("General SADL Settings");
-		addField(new StringFieldEditor(SadlPreferences.SADL_BASE_URI.getId(), "Base URI:", generalSettings) {
-
-			@Override
-			protected void doStore() {
-				getPreferenceStore().putValue(getPreferenceName(), getTextControl().getText());
-			}
-
-		});
-		addField(new RadioGroupFieldEditor(SadlPreferences.OWL_MODEL_FORMAT.getId(), "Saved OWL model format :", 5,
+		Composite generalSettings = createSettingsGroup(getFieldEditorParent(), SWT.NONE, "General SADL Settings");
+		addField(new StringFieldEditorExt(SADL_BASE_URI.getId(), "Base URI:", generalSettings));
+		addField(new RadioGroupFieldEditorExt(OWL_MODEL_FORMAT.getId(), "Saved OWL model format :", 5,
 				new String[][] {
-						{ SadlPreferences.RDF_XML_ABBREV_FORMAT.getId(),
-								SadlPreferences.RDF_XML_ABBREV_FORMAT.getId() },
-						{ SadlPreferences.RDF_XML_FORMAT.getId(), SadlPreferences.RDF_XML_FORMAT.getId() },
-						{ SadlPreferences.N3_FORMAT.getId(), SadlPreferences.N3_FORMAT.getId() },
-						{ SadlPreferences.N_TRIPLE_FORMAT.getId(), SadlPreferences.N_TRIPLE_FORMAT.getId() },
-						{ SadlPreferences.JENA_TDB.getId(), SadlPreferences.JENA_TDB.getId() }, },
-				generalSettings) {
+					{ RDF_XML_ABBREV_FORMAT.getId(), RDF_XML_ABBREV_FORMAT.getId() },
+					{ RDF_XML_FORMAT.getId(), RDF_XML_FORMAT.getId() },
+					{ N3_FORMAT.getId(), N3_FORMAT.getId() },
+					{ N_TRIPLE_FORMAT.getId(), N_TRIPLE_FORMAT.getId() },
+					{ JENA_TDB.getId(), JENA_TDB.getId() },
+				}, generalSettings));
+		addField(new RadioGroupFieldEditorExt("importBy", "Show import model list as:", 2,
+				new String[][] {
+					{ "Model Namespaces", MODEL_NAMESPACES.getId() },
+					{ "SADL File Names", SADL_FILE_NAMES.getId() }
+				}, generalSettings));
+		addField(new BooleanFieldEditorExt(PREFIXES_ONLY_AS_NEEDED.getId(), "Show prefixes for imported concepts only when needed for disambiguation", generalSettings));
+		addField(new BooleanFieldEditorExt(SHOW_TIMING_INFORMATION.getId(), "Show Timing Informaton (Build, Reasoning)", generalSettings));
+		addField(new RadioGroupFieldEditorExt("dmyOrder", "Interpret Date 10/11/2012 as:", 2,
+				new String[][] {
+					{ "MM/DD/YYYY", DMY_ORDER_MDY.getId() },
+					{ "DD/MM/YYYY", DMY_ORDER_DMY.getId() }
+				}, generalSettings));
+		addField(new BooleanFieldEditorExt(CHECK_FOR_AMBIGUOUS_NAMES.getId(), "Check for ambiguous names", generalSettings));
 
-			@Override
-			protected void doStore() {
-				doStoreFieldEditorValue(this);
-			}
-
-		});
-		addField(
-				new RadioGroupFieldEditor("importBy", "Show import model list as:", 2,
-						new String[][] { { "Model Namespaces", SadlPreferences.MODEL_NAMESPACES.getId() },
-								{ "SADL File Names", SadlPreferences.SADL_FILE_NAMES.getId() } },
-						generalSettings) {
-
-					@Override
-					protected void doStore() {
-						doStoreFieldEditorValue(this);
-					}
-
-				});
-		addField(new BooleanFieldEditor(SadlPreferences.PREFIXES_ONLY_AS_NEEDED.getId(),
-				"Show prefixes for imported concepts only when needed for disambiguation", generalSettings) {
-
-			@Override
-			protected void doStore() {
-				getPreferenceStore().putValue(getPreferenceName(), Boolean.toString(getBooleanValue()));
-			}
-
-		});
-		addField(new BooleanFieldEditor(SadlPreferences.SHOW_TIMING_INFORMATION.getId(),
-				"Show Timing Informaton (Build, Reasoning)", generalSettings) {
-
-			@Override
-			protected void doStore() {
-				getPreferenceStore().putValue(getPreferenceName(), Boolean.toString(getBooleanValue()));
-			}
-
-		});
-		addField(new RadioGroupFieldEditor("dmyOrder", "Interpret Date 10/11/2012 as:", 2,
-				new String[][] { { "MM/DD/YYYY", SadlPreferences.DMY_ORDER_MDY.getId() },
-						{ "DD/MM/YYYY", SadlPreferences.DMY_ORDER_DMY.getId() } },
-				generalSettings) {
-
-			@Override
-			protected void doStore() {
-				doStoreFieldEditorValue(this);
-			}
-
-		});
-		addField(new BooleanFieldEditor(SadlPreferences.CHECK_FOR_AMBIGUOUS_NAMES.getId(), "Check for ambiguous names",
-				generalSettings) {
-
-			@Override
-			protected void doStore() {
-				getPreferenceStore().putValue(getPreferenceName(), Boolean.toString(getBooleanValue()));
-			}
-
-		});
-		
 		// Graph Settings
-		Group graphSettings = new Group(getFieldEditorParent(), SWT.NONE);
-		graphSettings.setLayout(new FillLayout(SWT.HORIZONTAL));
-		graphSettings.setText("Graphing Settings");
-		addField(new StringFieldEditor(SadlPreferences.GRAPH_RENDERER_CLASS.getId(), "Graph renderer package and class:",
-				graphSettings) {
-
-			@Override
-			protected void doStore() {
-				getPreferenceStore().putValue(getPreferenceName(), getTextControl().getText());
-			}
-
-		});
-		addField(new BooleanFieldEditor(SadlPreferences.GRAPH_IMPLICIT_ELEMENTS.getId(), "&Include Implicit Elements in Graph", 
-				graphSettings){
-			@Override
-			protected void doStore() {
-				getPreferenceStore().putValue(getPreferenceName(), Boolean.toString(getBooleanValue()));
-			}
-		});
-		addField(new BooleanFieldEditor(SadlPreferences.GRAPH_IMPLICIT_ELEMENT_INSTANCES.getId(), "&Include Implicit Element Instances in Graph", 
-				graphSettings){
-			@Override
-			protected void doStore() {
-				getPreferenceStore().putValue(getPreferenceName(), Boolean.toString(getBooleanValue()));
-			}
-		});
+		Composite graphSettings = createSettingsGroup(getFieldEditorParent(), SWT.NONE, "Graphing Settings");
+		addField(new StringFieldEditorExt(GRAPH_RENDERER_CLASS.getId(), "Graph renderer package and class:", graphSettings));
+		addField(new BooleanFieldEditorExt(GRAPH_IMPLICIT_ELEMENTS.getId(), "&Include Implicit Elements in Graph", graphSettings));
+		addField(new BooleanFieldEditorExt(GRAPH_IMPLICIT_ELEMENT_INSTANCES.getId(), "&Include Implicit Element Instances in Graph", graphSettings));
 
 		// Inference and Querying Settings
-		Group inferenceSettings = new Group(getFieldEditorParent(), SWT.NONE);
-		inferenceSettings.setLayout(new FillLayout(SWT.HORIZONTAL));
-		inferenceSettings.setText("Inference and Querying Settings");
-		addField(new BooleanFieldEditor(SadlPreferences.VALIDATE_BEFORE_TEST.getId(), "Validate before Testing",
-				inferenceSettings) {
-
-			@Override
-			protected void doStore() {
-				getPreferenceStore().putValue(getPreferenceName(), Boolean.toString(getBooleanValue()));
-			}
-
-		});
-//		addField(new BooleanFieldEditor(SadlPreferences.TEST_WITH_KSERVER.getId(), "Test/Query with Knowledge Server",
-//				inferenceSettings) {
-//
-//			@Override
-//			protected void doStore() {
-//				getPreferenceStore().putValue(getPreferenceName(), Boolean.toString(getBooleanValue()));
-//			}
-//
-//		});
-		addField(new BooleanFieldEditor(SadlPreferences.NAMESPACE_IN_QUERY_RESULTS.getId(),
-				"Show Namespaces in Query Results", inferenceSettings) {
-
-			@Override
-			protected void doStore() {
-				getPreferenceStore().putValue(getPreferenceName(), Boolean.toString(getBooleanValue()));
-			}
-
-		});
-		addField(new BooleanFieldEditor(SadlPreferences.DEEP_VALIDATION_OFF.getId(), "Disable Deep Validation of Model",
-				inferenceSettings) {
-
-			@Override
-			protected void doStore() {
-				getPreferenceStore().putValue(getPreferenceName(), Boolean.toString(getBooleanValue()));
-			}
-
-		});
-		addField(new StringFieldEditor(SadlPreferences.TABULAR_DATA_IMPORTER_CLASS.getId(), "Tabular data importer package and class:",
-				inferenceSettings) {
-
-			@Override
-			protected void doStore() {
-				getPreferenceStore().putValue(getPreferenceName(), getTextControl().getText());
-			}
-
-		});
+		Composite inferenceSettings = createSettingsGroup(getFieldEditorParent(), SWT.NONE, "Inference and Querying Settings");
+		addField(new BooleanFieldEditorExt(VALIDATE_BEFORE_TEST.getId(), "Validate before Testing", inferenceSettings));
+//		addField(new BooleanFieldEditorExt(TEST_WITH_KSERVER.getId(), "Test/Query with Knowledge Server", inferenceSettings));
+		addField(new BooleanFieldEditorExt(NAMESPACE_IN_QUERY_RESULTS.getId(), "Show Namespaces in Query Results", inferenceSettings));
+		addField(new BooleanFieldEditorExt(DEEP_VALIDATION_OFF.getId(), "Disable Deep Validation of Model", inferenceSettings));
+		addField(new StringFieldEditorExt(TABULAR_DATA_IMPORTER_CLASS.getId(), "Tabular data importer package and class:", inferenceSettings));
 
 		// Metrics Settings
-		Group metricsSettings = new Group(getFieldEditorParent(), SWT.NONE);
-		metricsSettings.setLayout(new FillLayout(SWT.HORIZONTAL));
-		metricsSettings.setText("Metrics Settings");
-		addField(new BooleanFieldEditor(SadlPreferences.GENERATE_METRICS_REPORT_ON_CLEAN_BUILD.getId(),
-				"Generate metrics report during project clean/build", metricsSettings) {
-			@Override
-			protected void doStore() {
-				getPreferenceStore().putValue(getPreferenceName(), Boolean.toString(getBooleanValue()));
-			}
-		});
-		addField(new FileFieldEditor(SadlPreferences.METRICS_QUERY_FILENAME.getId(), "File containing metric queries: ",
-				metricsSettings) {
+		Composite metricsSettings = createSettingsGroup(getFieldEditorParent(), SWT.NONE, "Metrics Settings");
+		addField(new BooleanFieldEditorExt(GENERATE_METRICS_REPORT_ON_CLEAN_BUILD.getId(), "Generate metrics report during project clean/build", metricsSettings));
+		addField(new FileFieldEditorExt(METRICS_QUERY_FILENAME.getId(), "File containing metric queries: ", metricsSettings));
 
-			@Override
-			protected void doStore() {
-				getPreferenceStore().putValue(getPreferenceName(), getTextControl().getText());
-			}
-
-		});
-		
 		// Translation Settings
-		Group translationSettings = new Group(getFieldEditorParent(), SWT.NONE);
-		translationSettings.setLayout(new FillLayout(SWT.HORIZONTAL));
-		translationSettings.setText("Translation Settings");
-		addField(new BooleanFieldEditor(SadlPreferences.P_USE_ARTICLES_IN_VALIDATION.getId(), "Use indefinite and definite articles in validation and translation", 
-				translationSettings) {
-			
-			@Override
-			protected void doStore() {
-				getPreferenceStore().putValue(getPreferenceName(), Boolean.toString(getBooleanValue()));
-			}
+		Composite translationSettings = createSettingsGroup(getFieldEditorParent(), SWT.NONE, "Translation Settings");
+		addField(new BooleanFieldEditorExt(P_USE_ARTICLES_IN_VALIDATION.getId(), "Use indefinite and definite articles in validation and translation", translationSettings));
+		addField(new BooleanFieldEditorExt(IGNORE_UNITTEDQUANTITIES.getId(), "Ignore Unitted Quantities (treat as numeric only) during translation", translationSettings));
+		addField(new BooleanFieldEditorExt(CREATE_DOMAIN_AND_RANGE_AS_UNION_CLASSES.getId(), "Translate multiple-class domain or range as union class (owl:unionOf)", translationSettings));
 
-		});
-		addField(new BooleanFieldEditor(SadlPreferences.IGNORE_UNITTEDQUANTITIES.getId(),
-				"Ignore Unitted Quantities (treat as numeric only) during translation", translationSettings) {
-
-			@Override
-			protected void doStore() {
-				getPreferenceStore().putValue(getPreferenceName(), Boolean.toString(getBooleanValue()));
-			}
-
-		});
-		addField(new BooleanFieldEditor(SadlPreferences.CREATE_DOMAIN_AND_RANGE_AS_UNION_CLASSES.getId(),
-				"Translate multiple-class domain or range as union class (owl:unionOf)", translationSettings) {
-
-			@Override
-			protected void doStore() {
-				getPreferenceStore().putValue(getPreferenceName(), Boolean.toString(getBooleanValue()));
-			}
-		});
-		
 		// Type Checking Settings
-		Group typeCheckSettings = new Group(getFieldEditorParent(), SWT.NONE);
-		typeCheckSettings.setLayout(new FillLayout(SWT.HORIZONTAL));
-		typeCheckSettings.setText("Type Checking Settings");	
-		addField(new BooleanFieldEditor(SadlPreferences.CHECK_FOR_CARDINALITY_OF_PROPERTY_IN_DOMAIN.getId(), "Check for cardinality of property on specific domain",
-				typeCheckSettings) {
-
-			@Override
-			protected void doStore() {
-				getPreferenceStore().putValue(getPreferenceName(), Boolean.toString(getBooleanValue()));
-			}
-
-		});
-		addField(new BooleanFieldEditor(SadlPreferences.TYPE_CHECKING_RANGE_REQUIRED.getId(),
-				"Property range specification required", typeCheckSettings) {
-
-			@Override
-			protected void doStore() {
-				getPreferenceStore().putValue(getPreferenceName(), Boolean.toString(getBooleanValue()));
-			}
-
-		});
-		addField(new BooleanFieldEditor(SadlPreferences.TYPE_CHECKING_WARNING_ONLY.getId(),
-				"Type checking issues as warning only", typeCheckSettings) {
-
-			@Override
-			protected void doStore() {
-				getPreferenceStore().putValue(getPreferenceName(), Boolean.toString(getBooleanValue()));
-			}
-
-		});
-
+		Composite typeCheckSettings = createSettingsGroup(getFieldEditorParent(), SWT.NONE, "Type Checking Settings");
+		addField(new BooleanFieldEditorExt(CHECK_FOR_CARDINALITY_OF_PROPERTY_IN_DOMAIN.getId(), "Check for cardinality of property on specific domain", typeCheckSettings));
+		addField(new BooleanFieldEditorExt(TYPE_CHECKING_RANGE_REQUIRED.getId(), "Property range specification required", typeCheckSettings));
+		addField(new BooleanFieldEditorExt(TYPE_CHECKING_WARNING_ONLY.getId(), "Type checking issues as warning only", typeCheckSettings));
 	}
-	
-	private void doStoreFieldEditorValue(RadioGroupFieldEditor editor) {
-		try {
-			Field field = RadioGroupFieldEditor.class.getDeclaredField("value");
-			field.setAccessible(true);
-			Object value = field.get(editor);
-			if (value instanceof String) {
-				editor.getPreferenceStore().putValue(editor.getPreferenceName(), (String) value);
-			} else {
-				editor.getPreferenceStore().setToDefault(editor.getPreferenceName());
-			}
-		} catch (Exception e) {
-			throw new RuntimeException(e);
-		}
-	}
-	
+
 	@Override
 	protected void performDefaults() {
 		initializeDefaultPreferences();
 		super.performDefaults();
 	}
-	
+
 	private void initializeDefaultPreferences() {
 		IPreferenceStore store = this.getPreferenceStore();
 
@@ -333,7 +239,7 @@ public class SadlRootPreferencePage extends LanguageRootPreferencePage {
 		
 		setPreferenceStore(store);
 	}
-	
+
 	@Override
 	public boolean performOk() {
 		boolean retVal = super.performOk();
@@ -415,5 +321,4 @@ public class SadlRootPreferencePage extends LanguageRootPreferencePage {
 		return retVal;
 	}
 
-	
 }


### PR DESCRIPTION
So that the field editor can be wrapped into Groups.

Closes #345.

`Enabled`:
![screen shot 2018-12-04 at 11 46 46](https://user-images.githubusercontent.com/1405703/49436940-a9d3ae00-f7ba-11e8-8ff0-3ac26efcbc64.jpg)

`Disabled`:
![screen shot 2018-12-04 at 11 46 57](https://user-images.githubusercontent.com/1405703/49436933-a50efa00-f7ba-11e8-8ad2-a64251aa4ae3.jpg)

`In Action`:
![screencast 2018-12-04 11-45-06](https://user-images.githubusercontent.com/1405703/49436959-b821ca00-f7ba-11e8-9f33-cbc735815aea.gif)

Signed-off-by: Akos Kitta <kittaakos@typefox.io>