### PR TITLE
Make ExecuteCommand create graphs too

### DIFF
--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.applications/META-INF/MANIFEST.MF
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.applications/META-INF/MANIFEST.MF
@@ -10,15 +10,21 @@ Export-Package: com.ge.research.sadl.applications;
    org.eclipse.core.runtime,
    org.eclipse.equinox.app,
    org.eclipse.ui.plugin"
-Require-Bundle: org.eclipse.core.runtime,
- org.eclipse.xtext,
- org.eclipse.ui.workbench,
+Require-Bundle: com.ge.research.jena,
  com.ge.research.sadl,
- com.ge.research.jena,
+ com.ge.research.sadl.ide,
+ com.ge.research.sadl.jena,
+ com.ge.research.sadl.ui,
  org.eclipse.core.resources,
+ org.eclipse.core.runtime,
+ org.eclipse.ui.workbench,
+ org.eclipse.xtext,
  org.eclipse.xtext.builder
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: com.ge.research.sadl.applications.Activator
-Import-Package: com.ge.research.sadl.jena,
+Import-Package: com.ge.research.sadl.ide.handlers,
+ com.ge.research.sadl.ide.utils,
+ com.ge.research.sadl.jena,
+ com.ge.research.sadl.ui.handlers,
  org.apache.log4j
 Automatic-Module-Name: com.ge.research.sadl.applications

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.applications/resources/ExecuteCommand.cmd
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.applications/resources/ExecuteCommand.cmd
@@ -5,4 +5,4 @@
 setlocal
 set WORKSPACE=..\workspace
 cd /d %~dp0
-%~dp0\eclipsec.exe -console -noSplash -data %WORKSPACE% -application com.ge.research.sadl.applications.ExecuteCommand %*
+%~dp0\eclipsec.exe -noSplash -data %WORKSPACE% -application com.ge.research.sadl.applications.ExecuteCommand %*

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.applications/resources/ExecuteCommand.sh
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.applications/resources/ExecuteCommand.sh
@@ -4,4 +4,4 @@
 ##############################################################################
 WORKSPACE=../workspace
 cd -P -- "$(dirname -- "$0")"
-./eclipse -console -noSplash -data $WORKSPACE -application com.ge.research.sadl.applications.ExecuteCommand "$@"
+./eclipse -noSplash -data $WORKSPACE -application com.ge.research.sadl.applications.ExecuteCommand "$@"

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.applications/resources/SadlConfiguration.xml
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.applications/resources/SadlConfiguration.xml
@@ -12,17 +12,21 @@
 		<setting label="ShowTimingInformation" value="false"/>
 		<setting label="InterpretDateAs" value="MM/DD/YYYY"/><!--"DD/MM/YYYY"-->
 		<setting label="DisableDeepValidationOfModel" value="false"/>
-		<setting label="GraphRendererPackageAndClass" value=""/>
+		<setting label="GraphRendererPackageAndClass" value="com.ge.research.sadl.model.visualizer.GraphVizVisualizer"/>
+		<setting label="TabularDataImporterClass" value="com.ge.research.sadl.jena.importer.CsvImporter"/>
 		<setting label="IncludeImplicitElementsInGraph" value="false"/>
 		<setting label="IncludeImplicitElementInstancesInGraph" value="false"/>
 		<setting label="CheckForAmbiguousNames" value="true"/>
 		<setting label="CheckForCardinalityOfPropertyOnSpecificDomain" value="false"/>
 		<setting label="UseIndefiniteAndDefiniteArticlesInValidationAndTranslation" value="true"/>
 		<setting label="TypeCheckingWarningOnly" value="false"/>
+		<setting label="TypeCheckingRangeRequired" value="true"/>
 		<setting label="IgnoreUnittedQuantitiesDuringTranslation" value="false"/>
 		<setting label="IncludeImpliedPropertiesInTranslation" value="false"/>
 		<setting label="TranslateMultipleClassDomainOrRangeAsUnionClass" value="true"/>
 		<setting label="GenerateMetricsReportDuringProjectCleanBuild" value="false"/>
 		<setting label="FileContainingMetricQueries" value="SadlQueries.txt"/>
+		<setting label="GraphImplicitElements" value="false"/>
+		<setting label="GraphImplicitElementInstances" value="false"/>
 	</preferences>
 </SadlConfiguration>

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.applications/resources/log4j.properties
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.applications/resources/log4j.properties
@@ -1,16 +1,12 @@
-# SADL debugger control file
-
-# Change the primary logging level to INFO, WARN, ERROR, or OFF 
+# Change the primary logging level to DEBUG, INFO, WARN, ERROR, or OFF
 log4j.rootLogger=INFO, stdout
 
-# Print logging messages on standard output
-# Use a shortened layout without the year, month, day, or package name
+# Print logging messages on standard output using a shortened layout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{HH:mm:ss.SSS} %-5p %c{1}:%L - %m%n
+log4j.appender.stdout.layout.ConversionPattern=%d{HH:mm:ss.SSS} %-5p %m%n
+#log4j.appender.STDOUT.layout.ConversionPattern=%d [%t] %-5p %c - %m%n
 
-# Add any packages that you want to independently change the logging level
-# From most detailed to least: TRACE, DEBUG, INFO, WARN, ERROR, FATAL, OFF 
-log4j.logger.com.ge.research.sadl.reasoner.ConfigurationManager=DEBUG
-log4j.logger.com.ge.research.sadl.reasoner.ConfigurationManagerForEditing=DEBUG
-log4j.logger.com.ge.research.sadl.requirementsbuilder.ConfigurationManagerForIDE=DEBUG
+# Independently change the logging level for any packages below from
+# most detailed to least: TRACE, DEBUG, INFO, WARN, ERROR, FATAL, OFF
+#log4j.logger.com.ge.research.sadl.reasoner.ConfigurationManager=DEBUG

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.applications/src/com/ge/research/sadl/applications/Activator.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.applications/src/com/ge/research/sadl/applications/Activator.java
@@ -3,41 +3,37 @@ package com.ge.research.sadl.applications;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
 
-/**
- * The activator class controls the plug-in life cycle
- */
+/** The activator class controls the plug-in life cycle */
 public class Activator extends AbstractUIPlugin {
 
-	// The plug-in ID
-	public static final String PLUGIN_ID = "com.ge.research.sadl.applications.ExecuteCommand"; //$NON-NLS-1$
+    // The plug-in ID
+    public static final String PLUGIN_ID =
+            "com.ge.research.sadl.applications.ExecuteCommand"; //$NON-NLS-1$
 
-	private static Activator plugin;
+    private static Activator plugin;
 
-	private static Activator INSTANCE;
+    private static Activator INSTANCE;
 
-	public Activator() {
+    public Activator() {}
 
-	}
+    @Override
+    public void start(BundleContext context) throws Exception {
+        super.start(context);
+        plugin = this;
+        INSTANCE = this;
+    }
 
-	@Override
-	public void start(BundleContext context) throws Exception {
-		super.start(context);
-		plugin = this;
-		INSTANCE = this;
-	}
+    @Override
+    public void stop(BundleContext context) throws Exception {
+        plugin = null;
+        INSTANCE = null;
+    }
 
-	@Override
-	public void stop(BundleContext context) throws Exception {
-		plugin = null;
-		INSTANCE = null;
-	}
+    public static Activator getDefault() {
+        return plugin;
+    }
 
-	public static Activator getDefault() {
-		return plugin;
-	}
-
-	public static Activator getInstance() {
-		return INSTANCE;
-	}
+    public static Activator getInstance() {
+        return INSTANCE;
+    }
 }
-

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.applications/src/com/ge/research/sadl/applications/ExecuteCommand.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.applications/src/com/ge/research/sadl/applications/ExecuteCommand.java
@@ -1,5 +1,12 @@
 package com.ge.research.sadl.applications;
 
+import com.ge.research.sadl.ide.handlers.SadlRunInferenceHandler;
+import com.ge.research.sadl.jena.JenaBasedSadlModelProcessor;
+import com.ge.research.sadl.preferences.SadlPreferences;
+import com.ge.research.sadl.processing.ISadlImplicitModelContentProvider;
+import com.ge.research.sadl.processing.SadlConstants;
+import com.google.common.base.Supplier;
+import com.google.inject.Injector;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -11,12 +18,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
-
 import org.apache.jena.atlas.logging.LogCtl;
-import org.apache.log4j.Logger;
 import org.apache.log4j.PropertyConfigurator;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
@@ -43,589 +47,664 @@ import org.eclipse.xtext.util.CancelIndicator;
 import org.eclipse.xtext.validation.CheckMode;
 import org.eclipse.xtext.validation.IResourceValidator;
 import org.osgi.service.prefs.BackingStoreException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
-import com.ge.research.sadl.jena.JenaBasedSadlModelProcessor;
-import com.ge.research.sadl.preferences.SadlPreferences;
-import com.ge.research.sadl.processing.ISadlImplicitModelContentProvider;
-import com.ge.research.sadl.processing.ISadlInferenceProcessor;
-import com.ge.research.sadl.processing.SadlConstants;
-import com.ge.research.sadl.processing.SadlInferenceProcessorProvider;
-import com.google.inject.Injector;
-
-// Based on com.ge.aviation.sadl.requirements.command_line.ExecuteToolChain with all ASSERT-specific parts removed
+// Based on com.ge.aviation.sadl.requirements.command_line.ExecuteToolChain with all ASSERT-specific
+// parts removed
 @SuppressWarnings("restriction")
 public class ExecuteCommand implements IApplication {
 
-	//Logger to print what we do
-	private Logger logger = Logger.getLogger(ExecuteCommand.class);
+    // Logger to print what we do
+    private Logger logger = LoggerFactory.getLogger(ExecuteCommand.class);
 
-	//Default Configuration file location
-	private String configFilePath = "SadlConfiguration.xml";
+    // Default Configuration file location
+    private String configFilePath = "SadlConfiguration.xml";
 
-	//Files in OwlModels that we need to keep
-//	private final String configurationRdfFileName = "configuration.rdf";
-//	private final String ontPolicyRdfFileName = "ont-policy.rdf";
+    // Files in OwlModels that we need to keep
+    //    private final String configurationRdfFileName = "configuration.rdf";
+    //    private final String ontPolicyRdfFileName = "ont-policy.rdf";
 
-	//Essential Directories and Files for SADL
-	private File importDirectory;
-	private File owlModelDirectory;
-	private String runInferenceFilePath;
+    // Essential Directories and Files for SADL
+    private File importDirectory;
+    private File owlModelDirectory;
+    private String runInferenceFilePath;
 
-	//Preference Mappings
-	private Map<String, String> sadlPreferences;
+    // Preference Mappings
+    private Map<String, String> sadlPreferences;
 
-	//Project files to load into memory
-	private ArrayList<File> sadlFiles;
-	private ArrayList<File> sreqFiles;
-	private ArrayList<File> sverFiles;
+    // Project files to load into memory
+    private ArrayList<File> sadlFiles;
+    private ArrayList<File> sreqFiles;
+    private ArrayList<File> sverFiles;
 
-	//Instances and resources loaded into memory
-	private Injector injector;
-	private XtextResourceSet resourceSet;
+    // Instances and resources loaded into memory
+    private Injector injector;
+    private XtextResourceSet resourceSet;
 
-	//Control flow flags
-	private boolean inferFlag = false;
+    // Control flow flags
+    private boolean inferFlag = false;
 
-	//Overwrite flag
-	private boolean forceFlag = false;
+    // Overwrite flag
+    private boolean forceFlag = false;
 
-	//Default preferences
-	private boolean eclipseRefreshEnabled = false;
-	private boolean eclipseRefreshLightweightEnabled = false;
+    // Default preferences
+    private boolean eclipseRefreshEnabled = false;
+    private boolean eclipseRefreshLightweightEnabled = false;
 
-	public ExecuteCommand() {
-		this.sadlPreferences = new HashMap<String, String>();
+    public ExecuteCommand() {
+        this.sadlPreferences = new HashMap<String, String>();
 
-		//Configure to avoid log4j warning messages on startup
-		Properties log4jProperties = new Properties();
-		log4jProperties.setProperty("log4j.rootLogger", "INFO, stdout");
-		log4jProperties.setProperty("log4j.appender.stdout", "org.apache.log4j.ConsoleAppender");
-		log4jProperties.setProperty("log4j.appender.stdout.layout", "org.apache.log4j.PatternLayout");
-		log4jProperties.setProperty("log4j.appender.stdout.layout.ConversionPattern", "%-5p %m%n");
-		PropertyConfigurator.configure(log4jProperties);
-		LogCtl.setCmdLogging();
-	}
+        // Configure to avoid log4j warning messages on startup
+        Properties log4jProperties = new Properties();
+        log4jProperties.setProperty("log4j.rootLogger", "INFO, stdout");
+        log4jProperties.setProperty("log4j.appender.stdout", "org.apache.log4j.ConsoleAppender");
+        log4jProperties.setProperty(
+                "log4j.appender.stdout.layout", "org.apache.log4j.PatternLayout");
+        log4jProperties.setProperty("log4j.appender.stdout.layout.ConversionPattern", "%-5p %m%n");
+        PropertyConfigurator.configure(log4jProperties);
+        LogCtl.setCmdLogging();
+    }
 
-	@Override
-	public void stop() {
-		this.importDirectory = null;
-		this.owlModelDirectory = null;
-		this.runInferenceFilePath = null;
-		this.sadlPreferences.clear();
-		this.inferFlag = false;
-		this.forceFlag = false;
-	}
+    @Override
+    public void stop() {
+        this.importDirectory = null;
+        this.owlModelDirectory = null;
+        this.runInferenceFilePath = null;
+        this.sadlPreferences.clear();
+        this.inferFlag = false;
+        this.forceFlag = false;
+    }
 
-	@Override
-	public Object start(IApplicationContext context) throws Exception {
-		//Obtain command line arguments
-		final Map <?,?> argsMap = context.getArguments();
-		final String[] args = (String[]) argsMap.get("application.args");
+    @Override
+    public Object start(IApplicationContext context) throws Exception {
+        // Obtain command line arguments
+        final Map<?, ?> argsMap = context.getArguments();
+        final String[] args = (String[]) argsMap.get("application.args");
 
-		refreshWorkspace();
+        refreshWorkspace();
 
-		//Gets input/ted directories
-		if(!obtainArguments(args)){
-			return null;
-		}
+        // Gets input/ted directories
+        if (!obtainArguments(args)) {
+            return null;
+        }
 
-		//Load and set the preferences for SADL
-		if(!loadPreferences()){
-			return null;
-		}
+        // Load and set the preferences for SADL
+        if (!loadPreferences()) {
+            return null;
+        }
 
-		//Set Eclipse Preferences to compatible values for SADL CLI
-		setEclipsePreferences();
+        // Set Eclipse Preferences to compatible values for SADL CLI
+        setEclipsePreferences();
 
-		//Import project if not already part of workspace
-		if(!importProject()) {
-			return null;
-		}
+        // Import project if not already part of workspace
+        if (!importProject()) {
+            return null;
+        }
 
-		refreshWorkspace();
+        refreshWorkspace();
 
-		//Is project being processed open
-		if(!isProjectOpen()) {
-			return null;
-		}
+        // Is project being processed open
+        if (!isProjectOpen()) {
+            return null;
+        }
 
-		//Create Resources from sadl/sreq files and initiate Direct-Write
-		if(inferFlag) {
-			if(!importAndBuildSadlProject()){
-				logger.error("Failure on import and build of SADL Project");
-				return null;
-			}
-		}
+        // Create Resources from sadl/sreq files and initiate Direct-Write
+        if (inferFlag) {
+            if (!importAndBuildSadlProject()) {
+                logger.error("Failure on import and build of SADL Project");
+                return null;
+            }
+        }
 
-		//Invoke SADL RunInference Tool
-		if(inferFlag) {
-			if(!runInference()) {
-				logger.error("Failure on inference of SADL file");
-				return null;
-			}
-		}
+        // Invoke SADL RunInference Tool
+        if (inferFlag) {
+            if (!runInference()) {
+                logger.error("Failure on inference of SADL file");
+                return null;
+            }
+        }
 
-		//Restore Eclipse Preferences
-		restoreEclipsePreferences();
-		refreshWorkspace();
+        // Restore Eclipse Preferences
+        restoreEclipsePreferences();
+        refreshWorkspace();
 
-		logger.info("SADL Command-Line Interface complete");
+        logger.info("SADL Command-Line Interface complete");
 
-		return IApplication.EXIT_OK;
-	}
+        return IApplication.EXIT_OK;
+    }
 
-	private boolean importProject() {
-		IWorkspace workspace = ResourcesPlugin.getWorkspace();
-		IWorkspaceRoot root = workspace.getRoot();
+    private boolean importProject() {
+        IWorkspace workspace = ResourcesPlugin.getWorkspace();
+        IWorkspaceRoot root = workspace.getRoot();
 
-		//Check to see if import directory is within workspace
-		if(this.importDirectory.getAbsolutePath().contains(root.getLocation().makeAbsolute().toOSString())) {
-			return true;
-		}
+        // Check to see if import directory is within workspace
+        if (this.importDirectory
+                .getAbsolutePath()
+                .contains(root.getLocation().makeAbsolute().toOSString())) {
+            return true;
+        }
 
-		//Check to see if project already exists within workspace
-		for(IProject project : root.getProjects()) {
-			String projectName = project.getName();
-			if(this.importDirectory.getName().equals(projectName)) {
-				if(forceFlag) {
-					try {
-						project.delete(true, true, null);
-						break;
-					} catch (CoreException e) {
-						logger.error("Preexisting project could not be deleted from workspace: " + e);
-						return false;
-					}
-				}else {
-					logger.error("This project already exists within the workspace; use the \"-force\" flag to overwrite");
-					return false;
-				}
-			}
-		}
+        // Check to see if project already exists within workspace
+        for (IProject project : root.getProjects()) {
+            String projectName = project.getName();
+            if (this.importDirectory.getName().equals(projectName)) {
+                if (forceFlag) {
+                    try {
+                        project.delete(true, true, null);
+                        break;
+                    } catch (CoreException e) {
+                        logger.error(
+                                "Preexisting project could not be deleted from workspace: " + e);
+                        return false;
+                    }
+                } else {
+                    logger.error(
+                            "This project already exists within the workspace; use the \"-force\" flag to overwrite");
+                    return false;
+                }
+            }
+        }
 
-		//Make a new directory in workspace for project and copy
-		Path lNewProjectPath = Paths.get(root.getLocation().makeAbsolute().toOSString(), this.importDirectory.getName());
-		try {
-			if(!lNewProjectPath.toFile().exists()) {
-				Files.createDirectory(lNewProjectPath);
-			}
-			copyDirectory(this.importDirectory.toPath(), lNewProjectPath);
-		} catch (IOException e) {
-			logger.error("Unable to copy project into workspace: " + e);
-			return false;
-		}
-
-		//Import project into Eclipse workspace framework
-		try {
-			IProjectDescription description = workspace.loadProjectDescription(new org.eclipse.core.runtime.Path(lNewProjectPath.toAbsolutePath() + "/.project"));
-			IProject project = root.getProject(description.getName());
-			project.create(description, null);
-			project.open(null);
-		} catch (CoreException e) {
-			logger.error("Unable to import project into workspace: " + e);
-			return false;
-		}
-
-		//Set new import directory
-		this.importDirectory = lNewProjectPath.toFile();
-
-		return true;
-	}
-
-	private boolean copyDirectory(Path aSource, Path aDestination) throws IOException {
-		Files.walk(aSource).forEach(lSource -> copy(lSource, aDestination.resolve(aSource.relativize(lSource))));
-		return true;
-	}
-
-	private void copy(Path aSource, Path aDestination){
+        // Make a new directory in workspace for project and copy
+        Path lNewProjectPath =
+                Paths.get(
+                        root.getLocation().makeAbsolute().toOSString(),
+                        this.importDirectory.getName());
         try {
-			Files.copy(aSource, aDestination, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
-		} catch (IOException e) {
-			logger.error("Unable to copy file to workspace: " + aSource);
-		}
-	}
+            if (!lNewProjectPath.toFile().exists()) {
+                Files.createDirectory(lNewProjectPath);
+            }
+            copyDirectory(this.importDirectory.toPath(), lNewProjectPath);
+        } catch (IOException e) {
+            logger.error("Unable to copy project into workspace: " + e);
+            return false;
+        }
 
-	private boolean isProjectOpen() {
-		IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
-		for(IProject project : root.getProjects()) {
-			String projectName = project.getName();
-			if(this.importDirectory.getName().equals(projectName)) {
-				if(project.isOpen()) {
-					return true;
-				}else {
-					try {
-						project.open(null);
-					} catch (CoreException e) {
-						logger.error(projectName + " cannot be opened through this interface. Please open project within SADL GUI and execute again.");
-						return false;
-					}
-					return true;
-				}
-			}
-		}
+        // Import project into Eclipse workspace framework
+        try {
+            IProjectDescription description =
+                    workspace.loadProjectDescription(
+                            new org.eclipse.core.runtime.Path(
+                                    lNewProjectPath.toAbsolutePath() + "/.project"));
+            IProject project = root.getProject(description.getName());
+            project.create(description, null);
+            project.open(null);
+        } catch (CoreException e) {
+            logger.error("Unable to import project into workspace: " + e);
+            return false;
+        }
 
-		logger.error("The project that is attempting to be processed is not part of the current workspace. Please set the correct workspace location within the .cmd file.");
-		return false;
-	}
+        // Set new import directory
+        this.importDirectory = lNewProjectPath.toFile();
 
-	private boolean refreshWorkspace() {
-		try {
-			IWorkspaceRoot workspaceRoot = ResourcesPlugin.getWorkspace().getRoot();
-			workspaceRoot.refreshLocal(IResource.DEPTH_INFINITE, null);
-		} catch (CoreException e) {
-			logger.error("Error refreshing workspace: " + e);
-		}
-		return true;
-	}
+        return true;
+    }
 
-	private void setEclipsePreferences() {
-		IEclipsePreferences ep = InstanceScope.INSTANCE.getNode("org.eclipse.core.resources");
-		this.eclipseRefreshEnabled = ep.getBoolean(ResourcesPlugin.PREF_AUTO_REFRESH, false);
-		this.eclipseRefreshLightweightEnabled = ep.getBoolean(ResourcesPlugin.PREF_LIGHTWEIGHT_AUTO_REFRESH, false);
-		ep.putBoolean(ResourcesPlugin.PREF_AUTO_REFRESH, false);
-		ep.putBoolean(ResourcesPlugin.PREF_LIGHTWEIGHT_AUTO_REFRESH, false);
-		try {
-			ep.flush();
-		} catch (BackingStoreException e) {
-			logger.error("Error setting Eclipse preferences: " + e);
-		}
-	}
+    private boolean copyDirectory(Path aSource, Path aDestination) throws IOException {
+        Files.walk(aSource)
+                .forEach(
+                        lSource ->
+                                copy(lSource, aDestination.resolve(aSource.relativize(lSource))));
+        return true;
+    }
 
-	private void restoreEclipsePreferences() {
-		IEclipsePreferences ep = InstanceScope.INSTANCE.getNode("org.eclipse.core.resources");
-		ep.putBoolean(ResourcesPlugin.PREF_AUTO_REFRESH, this.eclipseRefreshEnabled);
-		ep.putBoolean(ResourcesPlugin.PREF_LIGHTWEIGHT_AUTO_REFRESH, eclipseRefreshLightweightEnabled);
-		try {
-			ep.flush();
-		} catch (BackingStoreException e) {
-			logger.error("Error restoring Eclipse preferences: " + e);
-		}
-	}
+    private void copy(Path aSource, Path aDestination) {
+        try {
+            Files.copy(aSource, aDestination, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException e) {
+            logger.error("Unable to copy file to workspace: " + aSource);
+        }
+    }
 
-	private boolean loadPreferences() {
-		//Default location, will be update later to be passed in as argument perhaps
-		File configFile = new File(this.configFilePath);
-		if(!configFile.exists()){
-			logger.error("Configuration file " + configFile + " does not exist");
-			return false;
-		}
+    private boolean isProjectOpen() {
+        IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
+        for (IProject project : root.getProjects()) {
+            String projectName = project.getName();
+            if (this.importDirectory.getName().equals(projectName)) {
+                if (project.isOpen()) {
+                    return true;
+                } else {
+                    try {
+                        project.open(null);
+                    } catch (CoreException e) {
+                        logger.error(
+                                projectName
+                                        + " cannot be opened through this interface. Please open project within SADL GUI and execute again.");
+                        return false;
+                    }
+                    return true;
+                }
+            }
+        }
 
-		try{
-			//load the xml
-			DocumentBuilderFactory xmlDocFactory = DocumentBuilderFactory.newInstance();
-			DocumentBuilder xmlDocBuilder = xmlDocFactory.newDocumentBuilder();
-			Document xmlDoc = xmlDocBuilder.parse(configFile);
-			NodeList prefNodes = xmlDoc.getElementsByTagName("preferences");
-			for(int i = 0; i < prefNodes.getLength(); i++){
-				Element prefElement = (Element) prefNodes.item(i);
-				String prefAttribute = prefElement.getAttribute("id");
-				//Handle sadl preferences
-				if(prefAttribute.equals("SADL")){
-					NodeList sadlNodes = prefElement.getElementsByTagName("setting");
-					for(int x = 0; x < sadlNodes.getLength(); x++){
-						Element sadlElement = (Element) sadlNodes.item(x);
-						String sadlLabel = sadlElement.getAttribute("label");
-						String sadlValue = sadlElement.getAttribute("value");
-						//If no value is set, skip and use default
-						if(sadlValue.isEmpty()){
-							continue;
-						}
-						if(sadlLabel.equals("BaseURI")){
-							sadlPreferences.put(SadlPreferences.SADL_BASE_URI.getId(), sadlValue);
-						}else if(sadlLabel.equals("SavedOWLModelFormat")){
-							if(sadlValue.replace(" ","").toLowerCase().equals("rdf/xml-abbrev")){
-								sadlPreferences.put(SadlPreferences.OWL_MODEL_FORMAT.getId(),
-														   SadlPreferences.RDF_XML_ABBREV_FORMAT.getId());
-							}else if(sadlValue.replace(" ","").toLowerCase().equals("rdf/xml")){
-								sadlPreferences.put(SadlPreferences.OWL_MODEL_FORMAT.getId(),
-										   			SadlPreferences.RDF_XML_FORMAT.getId());
-							}else if(sadlValue.replace(" ","").toLowerCase().equals("n3")){
-								sadlPreferences.put(SadlPreferences.OWL_MODEL_FORMAT.getId(),
-							   						SadlPreferences.N3_FORMAT.getId());
-							}else if(sadlValue.replace(" ","").toLowerCase().equals("n-triple")){
-								sadlPreferences.put(SadlPreferences.OWL_MODEL_FORMAT.getId(),
-							   						SadlPreferences.N_TRIPLE_FORMAT.getId());
-							}else if(sadlValue.replace(" ","").toLowerCase().equals("jenatbd")){
-								sadlPreferences.put(SadlPreferences.OWL_MODEL_FORMAT.getId(),
-													SadlPreferences.JENA_TDB.getId());
-							}
-						}else if(sadlLabel.equals("ShowImportModelListAs")){
-							if(sadlValue.replace(" ","").toLowerCase().equals("modelnamespaces")){
-								//TODO SadlPreference Key needed
-								sadlPreferences.put("importBy",
-													SadlPreferences.MODEL_NAMESPACES.getId());
-							}else if(sadlValue.replace(" ","").toLowerCase().equals("sadlfilenames")){
-								//TODO SadlPreference Key needed
-								sadlPreferences.put("importBy",
-										   			SadlPreferences.SADL_FILE_NAMES.getId());
-							}
-						}else if(sadlLabel.equals("ShowPrefixesForImportedConceptsOnlyWhenNeededForDisambiguation")){
-							sadlPreferences.put(SadlPreferences.PREFIXES_ONLY_AS_NEEDED.getId(), sadlValue);
-						}else if(sadlLabel.equals("ValidateBeforeTesting")){
-							sadlPreferences.put(SadlPreferences.VALIDATE_BEFORE_TEST.getId(), sadlValue);
-						}else if(sadlLabel.equals("Test/QueryWithKnowledgeServer")){
-							sadlPreferences.put(SadlPreferences.TEST_WITH_KSERVER.getId(), sadlValue);
-						}else if(sadlLabel.equals("ShowNamespacesInQueryResults")){
-							sadlPreferences.put(SadlPreferences.NAMESPACE_IN_QUERY_RESULTS.getId(), sadlValue);
-						}else if(sadlLabel.equals("ShowTimingInformation")){
-							sadlPreferences.put(SadlPreferences.SHOW_TIMING_INFORMATION.getId(), sadlValue);
-						}else if(sadlLabel.equals("InterpretDateAs")){
-							if(sadlValue.replace(" ","").toLowerCase().equals("mm/dd/yyyy")){
-								//TODO SadlPreference Key needed
-								sadlPreferences.put("dmyOrder",
-													SadlPreferences.DMY_ORDER_MDY.getId());
-							}else if(sadlValue.replace(" ","").toLowerCase().equals("dd/mm/yyyy")){
-								//TODO SadlPreference Key needed
-								sadlPreferences.put("dmyOrder",
-										   			SadlPreferences.DMY_ORDER_DMY.getId());
-							}
-						}else if(sadlLabel.equals("DisableDeepValidationOfModel")){
-							sadlPreferences.put(SadlPreferences.DEEP_VALIDATION_OFF.getId(), sadlValue);
-						}else if(sadlLabel.equals("GraphRendererPackageAndClass")){
-							sadlPreferences.put(SadlPreferences.GRAPH_RENDERER_CLASS.getId(), sadlValue);
-						}else if(sadlLabel.equals("IncludeImplicitElementsInGraph")) {
-							sadlPreferences.put(SadlPreferences.GRAPH_IMPLICIT_ELEMENTS.getId(), sadlValue);
-						}else if(sadlLabel.equals("IncludeImplicitElementInstancesInGraph")) {
-							sadlPreferences.put(SadlPreferences.GRAPH_IMPLICIT_ELEMENT_INSTANCES.getId(), sadlValue);
-						}else if(sadlLabel.equals("CheckForAmbiguousNames")){
-							sadlPreferences.put(SadlPreferences.CHECK_FOR_AMBIGUOUS_NAMES.getId(), sadlValue);
-						}else if(sadlLabel.equals("CheckForCardinalityOfPropertyOnSpecificDomain")) {
-							sadlPreferences.put(SadlPreferences.CHECK_FOR_CARDINALITY_OF_PROPERTY_IN_DOMAIN.getId(), sadlValue);
-						}else if(sadlLabel.equals("UseIndefiniteAndDefiniteArticlesInValidationAndTranslation")) {
-							sadlPreferences.put(SadlPreferences.P_USE_ARTICLES_IN_VALIDATION.getId(), sadlValue);
-						}else if(sadlLabel.equals("TypeCheckingWarningOnly")){
-							sadlPreferences.put(SadlPreferences.TYPE_CHECKING_WARNING_ONLY.getId(), sadlValue);
-						}else if(sadlLabel.equals("IgnoreUnittedQuantitiesDuringTranslation")){
-							sadlPreferences.put(SadlPreferences.IGNORE_UNITTEDQUANTITIES.getId(), sadlValue);
-						}
-						else if(sadlLabel.equals("TranslateMultipleClassDomainOrRangeAsUnionClass")) {
-							sadlPreferences.put(SadlPreferences.CREATE_DOMAIN_AND_RANGE_AS_UNION_CLASSES.getId(), sadlValue);
-						}else if(sadlLabel.equals("GenerateMetricsReportDuringProjectCleanBuild")){
-							sadlPreferences.put(SadlPreferences.GENERATE_METRICS_REPORT_ON_CLEAN_BUILD.getId(), sadlValue);
-						}else if(sadlLabel.equals("FileContainingMetricQueries")){
-							sadlPreferences.put(SadlPreferences.METRICS_QUERY_FILENAME.getId(), sadlValue);
-						}
-					}
-				}
-			}
-		} catch(Exception e){
-			logger.error("Error loading configuration file: " + e);
-			return false;
-		}
+        logger.error(
+                "The project that is attempting to be processed is not part of the current workspace. Please set the correct workspace location within the .cmd file.");
+        return false;
+    }
 
-		return true;
-	}
+    private boolean refreshWorkspace() {
+        try {
+            IWorkspaceRoot workspaceRoot = ResourcesPlugin.getWorkspace().getRoot();
+            workspaceRoot.refreshLocal(IResource.DEPTH_INFINITE, null);
+        } catch (CoreException e) {
+            logger.error("Error refreshing workspace: " + e);
+        }
+        return true;
+    }
 
-	private boolean obtainArguments(String[] args) {
-		String importDirectory = null;
-		String configFilePath = null;
-		String runInferenceFilePath = null;
+    private void setEclipsePreferences() {
+        IEclipsePreferences ep = InstanceScope.INSTANCE.getNode("org.eclipse.core.resources");
+        this.eclipseRefreshEnabled = ep.getBoolean(ResourcesPlugin.PREF_AUTO_REFRESH, false);
+        this.eclipseRefreshLightweightEnabled =
+                ep.getBoolean(ResourcesPlugin.PREF_LIGHTWEIGHT_AUTO_REFRESH, false);
+        ep.putBoolean(ResourcesPlugin.PREF_AUTO_REFRESH, false);
+        ep.putBoolean(ResourcesPlugin.PREF_LIGHTWEIGHT_AUTO_REFRESH, false);
+        try {
+            ep.flush();
+        } catch (BackingStoreException e) {
+            logger.error("Error setting Eclipse preferences: " + e);
+        }
+    }
 
-		for(int i = 0; i < args.length; i ++){
-			if(args[i].startsWith("-import")){
-				importDirectory = args[i].split("=")[1];
-			}else if(args[i].startsWith("-config")){
-				configFilePath = args[i].split("=")[1];
-			}else if(args[i].startsWith("-infer")){
-				runInferenceFilePath = args[i].split("=")[1];
-				this.inferFlag = true;
-			}else if(args[i].equals("-force")) {
-				this.forceFlag = true;
-			}
-		}
+    private void restoreEclipsePreferences() {
+        IEclipsePreferences ep = InstanceScope.INSTANCE.getNode("org.eclipse.core.resources");
+        ep.putBoolean(ResourcesPlugin.PREF_AUTO_REFRESH, this.eclipseRefreshEnabled);
+        ep.putBoolean(
+                ResourcesPlugin.PREF_LIGHTWEIGHT_AUTO_REFRESH, eclipseRefreshLightweightEnabled);
+        try {
+            ep.flush();
+        } catch (BackingStoreException e) {
+            logger.error("Error restoring Eclipse preferences: " + e);
+        }
+    }
 
-		if(importDirectory != null){
-    		this.importDirectory = new File(importDirectory);
-            if(!this.importDirectory.isDirectory()){
-            	logger.error("Given directory for -import argument was not valid");
-    			return false;
-    		}
-		} else {
-			logger.error("Argument is missing: -import=[Directory of Project]");
-			return false;
-		}
+    private boolean loadPreferences() {
+        // Default location, will be update later to be passed in as argument perhaps
+        File configFile = new File(this.configFilePath);
+        if (!configFile.exists()) {
+            logger.error("Configuration file " + configFile + " does not exist");
+            return false;
+        }
 
-		if(configFilePath != null){
-			this.configFilePath = configFilePath;
-		}
+        try {
+            // load the xml
+            DocumentBuilderFactory xmlDocFactory = DocumentBuilderFactory.newInstance();
+            DocumentBuilder xmlDocBuilder = xmlDocFactory.newDocumentBuilder();
+            Document xmlDoc = xmlDocBuilder.parse(configFile);
+            NodeList prefNodes = xmlDoc.getElementsByTagName("preferences");
+            for (int i = 0; i < prefNodes.getLength(); i++) {
+                Element prefElement = (Element) prefNodes.item(i);
+                String prefAttribute = prefElement.getAttribute("id");
+                // Handle sadl preferences
+                if (prefAttribute.equals("SADL")) {
+                    NodeList sadlNodes = prefElement.getElementsByTagName("setting");
+                    for (int x = 0; x < sadlNodes.getLength(); x++) {
+                        Element sadlElement = (Element) sadlNodes.item(x);
+                        String sadlLabel = sadlElement.getAttribute("label");
+                        String sadlValue = sadlElement.getAttribute("value");
+                        // If no value is set, skip and use default
+                        if (sadlValue.isEmpty()) {
+                            continue;
+                        }
+                        if (sadlLabel.equals("BaseURI")) {
+                            sadlPreferences.put(SadlPreferences.SADL_BASE_URI.getId(), sadlValue);
+                        } else if (sadlLabel.equals("SavedOWLModelFormat")) {
+                            if (sadlValue.replace(" ", "").toLowerCase().equals("rdf/xml-abbrev")) {
+                                sadlPreferences.put(
+                                        SadlPreferences.OWL_MODEL_FORMAT.getId(),
+                                        SadlPreferences.RDF_XML_ABBREV_FORMAT.getId());
+                            } else if (sadlValue.replace(" ", "").toLowerCase().equals("rdf/xml")) {
+                                sadlPreferences.put(
+                                        SadlPreferences.OWL_MODEL_FORMAT.getId(),
+                                        SadlPreferences.RDF_XML_FORMAT.getId());
+                            } else if (sadlValue.replace(" ", "").toLowerCase().equals("n3")) {
+                                sadlPreferences.put(
+                                        SadlPreferences.OWL_MODEL_FORMAT.getId(),
+                                        SadlPreferences.N3_FORMAT.getId());
+                            } else if (sadlValue
+                                    .replace(" ", "")
+                                    .toLowerCase()
+                                    .equals("n-triple")) {
+                                sadlPreferences.put(
+                                        SadlPreferences.OWL_MODEL_FORMAT.getId(),
+                                        SadlPreferences.N_TRIPLE_FORMAT.getId());
+                            } else if (sadlValue.replace(" ", "").toLowerCase().equals("jenatbd")) {
+                                sadlPreferences.put(
+                                        SadlPreferences.OWL_MODEL_FORMAT.getId(),
+                                        SadlPreferences.JENA_TDB.getId());
+                            }
+                        } else if (sadlLabel.equals("ShowImportModelListAs")) {
+                            if (sadlValue
+                                    .replace(" ", "")
+                                    .toLowerCase()
+                                    .equals("modelnamespaces")) {
+                                // TODO SadlPreference Key needed
+                                sadlPreferences.put(
+                                        "importBy", SadlPreferences.MODEL_NAMESPACES.getId());
+                            } else if (sadlValue
+                                    .replace(" ", "")
+                                    .toLowerCase()
+                                    .equals("sadlfilenames")) {
+                                // TODO SadlPreference Key needed
+                                sadlPreferences.put(
+                                        "importBy", SadlPreferences.SADL_FILE_NAMES.getId());
+                            }
+                        } else if (sadlLabel.equals(
+                                "ShowPrefixesForImportedConceptsOnlyWhenNeededForDisambiguation")) {
+                            sadlPreferences.put(
+                                    SadlPreferences.PREFIXES_ONLY_AS_NEEDED.getId(), sadlValue);
+                        } else if (sadlLabel.equals("ValidateBeforeTesting")) {
+                            sadlPreferences.put(
+                                    SadlPreferences.VALIDATE_BEFORE_TEST.getId(), sadlValue);
+                        } else if (sadlLabel.equals("Test/QueryWithKnowledgeServer")) {
+                            sadlPreferences.put(
+                                    SadlPreferences.TEST_WITH_KSERVER.getId(), sadlValue);
+                        } else if (sadlLabel.equals("ShowNamespacesInQueryResults")) {
+                            sadlPreferences.put(
+                                    SadlPreferences.NAMESPACE_IN_QUERY_RESULTS.getId(), sadlValue);
+                        } else if (sadlLabel.equals("ShowTimingInformation")) {
+                            sadlPreferences.put(
+                                    SadlPreferences.SHOW_TIMING_INFORMATION.getId(), sadlValue);
+                        } else if (sadlLabel.equals("InterpretDateAs")) {
+                            if (sadlValue.replace(" ", "").toLowerCase().equals("mm/dd/yyyy")) {
+                                // TODO SadlPreference Key needed
+                                sadlPreferences.put(
+                                        "dmyOrder", SadlPreferences.DMY_ORDER_MDY.getId());
+                            } else if (sadlValue
+                                    .replace(" ", "")
+                                    .toLowerCase()
+                                    .equals("dd/mm/yyyy")) {
+                                // TODO SadlPreference Key needed
+                                sadlPreferences.put(
+                                        "dmyOrder", SadlPreferences.DMY_ORDER_DMY.getId());
+                            }
+                        } else if (sadlLabel.equals("DisableDeepValidationOfModel")) {
+                            sadlPreferences.put(
+                                    SadlPreferences.DEEP_VALIDATION_OFF.getId(), sadlValue);
+                        } else if (sadlLabel.equals("GraphRendererPackageAndClass")) {
+                            sadlPreferences.put(
+                                    SadlPreferences.GRAPH_RENDERER_CLASS.getId(), sadlValue);
+                        } else if (sadlLabel.equals("TabularDataImporterClass")) {
+                            sadlPreferences.put(
+                                    SadlPreferences.TABULAR_DATA_IMPORTER_CLASS.getId(), sadlValue);
+                        } else if (sadlLabel.equals("IncludeImplicitElementsInGraph")) {
+                            sadlPreferences.put(
+                                    SadlPreferences.GRAPH_IMPLICIT_ELEMENTS.getId(), sadlValue);
+                        } else if (sadlLabel.equals("IncludeImplicitElementInstancesInGraph")) {
+                            sadlPreferences.put(
+                                    SadlPreferences.GRAPH_IMPLICIT_ELEMENT_INSTANCES.getId(),
+                                    sadlValue);
+                        } else if (sadlLabel.equals("CheckForAmbiguousNames")) {
+                            sadlPreferences.put(
+                                    SadlPreferences.CHECK_FOR_AMBIGUOUS_NAMES.getId(), sadlValue);
+                        } else if (sadlLabel.equals(
+                                "CheckForCardinalityOfPropertyOnSpecificDomain")) {
+                            sadlPreferences.put(
+                                    SadlPreferences.CHECK_FOR_CARDINALITY_OF_PROPERTY_IN_DOMAIN
+                                            .getId(),
+                                    sadlValue);
+                        } else if (sadlLabel.equals(
+                                "UseIndefiniteAndDefiniteArticlesInValidationAndTranslation")) {
+                            sadlPreferences.put(
+                                    SadlPreferences.P_USE_ARTICLES_IN_VALIDATION.getId(),
+                                    sadlValue);
+                        } else if (sadlLabel.equals("TypeCheckingWarningOnly")) {
+                            sadlPreferences.put(
+                                    SadlPreferences.TYPE_CHECKING_WARNING_ONLY.getId(), sadlValue);
+                        } else if (sadlLabel.equals("TypeCheckingRangeRequired")) {
+                            sadlPreferences.put(
+                                    SadlPreferences.TYPE_CHECKING_RANGE_REQUIRED.getId(),
+                                    sadlValue);
+                        } else if (sadlLabel.equals("IgnoreUnittedQuantitiesDuringTranslation")) {
+                            sadlPreferences.put(
+                                    SadlPreferences.IGNORE_UNITTEDQUANTITIES.getId(), sadlValue);
+                        } else if (sadlLabel.equals(
+                                "TranslateMultipleClassDomainOrRangeAsUnionClass")) {
+                            sadlPreferences.put(
+                                    SadlPreferences.CREATE_DOMAIN_AND_RANGE_AS_UNION_CLASSES
+                                            .getId(),
+                                    sadlValue);
+                        } else if (sadlLabel.equals(
+                                "GenerateMetricsReportDuringProjectCleanBuild")) {
+                            sadlPreferences.put(
+                                    SadlPreferences.GENERATE_METRICS_REPORT_ON_CLEAN_BUILD.getId(),
+                                    sadlValue);
+                        } else if (sadlLabel.equals("FileContainingMetricQueries")) {
+                            sadlPreferences.put(
+                                    SadlPreferences.METRICS_QUERY_FILENAME.getId(), sadlValue);
+                        } else if (sadlLabel.equals("GraphImplicitElements")) {
+                            sadlPreferences.put(
+                                    SadlPreferences.GRAPH_IMPLICIT_ELEMENTS.getId(), sadlValue);
+                        } else if (sadlLabel.equals("GraphImplicitElementInstances")) {
+                            sadlPreferences.put(
+                                    SadlPreferences.GRAPH_IMPLICIT_ELEMENT_INSTANCES.getId(),
+                                    sadlValue);
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            logger.error("Error loading configuration file: " + e);
+            return false;
+        }
 
-		if (runInferenceFilePath != null) {
-		    this.runInferenceFilePath = runInferenceFilePath;
-		    if (!new File(this.importDirectory, runInferenceFilePath).canRead()) {
-		    	logger.error("Given file for -infer argument was not valid");
-		        return false;
-		    }
-		} else {
-			logger.error("Argument is missing: -infer=[File to infer]");
-		    return false;
-		}
+        return true;
+    }
 
-		return true;
-	}
+    private boolean obtainArguments(String[] args) {
+        String importDirectory = null;
+        String configFilePath = null;
+        String runInferenceFilePath = null;
 
-	private boolean importAndBuildSadlProject(){
-		//Output Directory for OwlModels
-		this.owlModelDirectory = new File(this.importDirectory.getAbsolutePath(), "OwlModels");
-		if(this.owlModelDirectory == null){
-			return false;
-		}else if(!this.owlModelDirectory.exists()) {
-			this.owlModelDirectory.mkdir();
-		}
+        for (int i = 0; i < args.length; i++) {
+            if (args[i].startsWith("-import")) {
+                importDirectory = args[i].split("=")[1];
+            } else if (args[i].startsWith("-config")) {
+                configFilePath = args[i].split("=")[1];
+            } else if (args[i].startsWith("-infer")) {
+                runInferenceFilePath = args[i].split("=")[1];
+                this.inferFlag = true;
+            } else if (args[i].equals("-force")) {
+                this.forceFlag = true;
+            }
+        }
 
-		//Clean project before build
-		cleanProject();
+        if (importDirectory != null) {
+            this.importDirectory = new File(importDirectory);
+            if (!this.importDirectory.isDirectory()) {
+                logger.error("Given directory for -import argument was not valid");
+                return false;
+            }
+        } else {
+            logger.error("Argument is missing: -import=[Directory of Project]");
+            return false;
+        }
 
-		//Create Implicit Resources
-		createImplicitResources();
+        if (configFilePath != null) {
+            this.configFilePath = configFilePath;
+        }
 
-		//Obtain files from import directory recursively
-		sadlFiles = obtainFiles(this.importDirectory, new ArrayList<File>(), ".sadl");
-		sreqFiles = obtainFiles(this.importDirectory, new ArrayList<File>(), ".sreq");
-		sverFiles = obtainFiles(this.importDirectory, new ArrayList<File>(), ".sver");
+        if (runInferenceFilePath != null) {
+            this.runInferenceFilePath = runInferenceFilePath;
+            if (!new File(this.importDirectory, runInferenceFilePath).canRead()) {
+                logger.error("Given file for -infer argument was not valid");
+                return false;
+            }
+        } else {
+            logger.error("Argument is missing: -infer=[File to infer]");
+            return false;
+        }
 
-		//Create and register dependency injectors
-		injector = new SADLCliAppStandaloneSetup().createInjectorAndDoEMFRegistration();
+        return true;
+    }
 
-		//Obtain a resource set
-		resourceSet = injector.getInstance(XtextResourceSet.class);
+    private boolean importAndBuildSadlProject() {
+        // Output Directory for OwlModels
+        this.owlModelDirectory = new File(this.importDirectory.getAbsolutePath(), "OwlModels");
+        this.owlModelDirectory.mkdirs();
 
-		//Set Preferences
-		Map<String,String> fullPreferenceMap = new HashMap<String,String>();
-		PreferenceValuesByLanguage preferencesByLanguage = new PreferenceValuesByLanguage();
-		fullPreferenceMap.putAll(this.sadlPreferences);
-		preferencesByLanguage.put("com.ge.research.sadl.SADL", new MapBasedPreferenceValues(fullPreferenceMap));
-		preferencesByLanguage.attachToEmfObject(resourceSet);
+        // Clean project before build
+        cleanProject();
 
-		//build resource sets
-		logger.info("Creating resources in memory");
-		for (File file : sadlFiles) {
-			resourceSet.getResource(URI.createFileURI(file.getAbsolutePath()),true);
-		}
-		for (File file : sreqFiles) {
-			resourceSet.getResource(URI.createFileURI(file.getAbsolutePath()),true);
-		}
-		for(File file : sverFiles){
-			resourceSet.getResource(URI.createFileURI(file.getAbsolutePath()),true);
-		}
-		logger.info("Resolving interdependencies between resources");
-		EcoreUtil2.resolveAll(resourceSet);
+        // Create Implicit Resources
+        createImplicitResources();
 
-		//Direct Write
-		List<File> allFiles = new ArrayList<File>();
-		allFiles.addAll(sadlFiles);
-		allFiles.addAll(sreqFiles);
-		allFiles.addAll(sverFiles);
-		Iterator<File> i = allFiles.iterator();
-		while(i.hasNext()){
-			File file = i.next();
-			Resource resource = resourceSet.getResource(URI.createFileURI(file.getAbsolutePath()),true);
-			if (resource instanceof XtextResource) {
-				directWrite(resource);
-			}
-		}
+        // Obtain files from import directory recursively
+        sadlFiles = obtainFiles(this.importDirectory, new ArrayList<File>(), ".sadl");
+        sreqFiles = obtainFiles(this.importDirectory, new ArrayList<File>(), ".sreq");
+        sverFiles = obtainFiles(this.importDirectory, new ArrayList<File>(), ".sver");
 
-		return true;
-	}
+        // Create and register dependency injectors
+        injector = new SADLCliAppStandaloneSetup().createInjectorAndDoEMFRegistration();
 
-	private void cleanProject() {
-// If we clean these files first, ExecuteCommand reports errors when building the project:
-// ERROR com.ge.research.sadl.external.ExternalEmfResource - Error occurred while loading the resource. URI:platform:/resource/HawkeyeUAV/OwlModels/Components.owl
-// org.eclipse.emf.ecore.resource.Resource$IOWrappedException: Resource '/HawkeyeUAV/OwlModels/Components.owl' does not exist.
-//
-//		if(this.owlModelDirectory.exists()) {
-//			File[] files = this.owlModelDirectory.listFiles();
-//			for(File file : files) {
-//			    if (!file.getName().equals(configurationRdfFileName) && !file.getName().equals(ontPolicyRdfFileName)) {
-//			        file.delete();
-//			    }
-//			}
-//		}
-	}
+        // Obtain a resource set
+        resourceSet = injector.getInstance(XtextResourceSet.class);
 
-	private boolean runInference() {
-		try {
-			//Open the requested SADL resource within the newly imported project
-			final File runInferenceFile = new File(this.importDirectory, this.runInferenceFilePath);
-			final Resource sadlResource = resourceSet.getResource(URI.createFileURI(runInferenceFile.getAbsolutePath()), true);
-			logger.info("Inferencing " + runInferenceFile.toURI());
+        // Set Preferences
+        Map<String, String> fullPreferenceMap = new HashMap<String, String>();
+        PreferenceValuesByLanguage preferencesByLanguage = new PreferenceValuesByLanguage();
+        fullPreferenceMap.putAll(this.sadlPreferences);
+        preferencesByLanguage.put(
+                "com.ge.research.sadl.SADL", new MapBasedPreferenceValues(fullPreferenceMap));
+        preferencesByLanguage.attachToEmfObject(resourceSet);
 
-		    //Get the filename for the corresponding SAL model
-		    File sadlModel = new File(this.owlModelDirectory, replaceExtension(runInferenceFile.getName(), ".owl"));
+        // build resource sets
+        logger.info("Creating resources in memory");
+        for (File file : sadlFiles) {
+            resourceSet.getResource(URI.createFileURI(file.getAbsolutePath()), true);
+        }
+        for (File file : sreqFiles) {
+            resourceSet.getResource(URI.createFileURI(file.getAbsolutePath()), true);
+        }
+        for (File file : sverFiles) {
+            resourceSet.getResource(URI.createFileURI(file.getAbsolutePath()), true);
+        }
+        logger.info("Resolving interdependencies between resources");
+        EcoreUtil2.resolveAll(resourceSet);
 
-		    //Obtain the SADL inference processor
-		    SadlInferenceProcessorProvider inferenceProcessorProvider = injector.getInstance(SadlInferenceProcessorProvider.class);
-		    final ISadlInferenceProcessor inferenceProcessor = inferenceProcessorProvider.getProcessor(sadlResource);
+        // Direct Write
+        List<File> allFiles = new ArrayList<File>();
+        allFiles.addAll(sadlFiles);
+        allFiles.addAll(sreqFiles);
+        allFiles.addAll(sverFiles);
+        Iterator<File> i = allFiles.iterator();
+        while (i.hasNext()) {
+            File file = i.next();
+            Resource resource =
+                    resourceSet.getResource(URI.createFileURI(file.getAbsolutePath()), true);
+            if (resource instanceof XtextResource) {
+                directWrite(resource);
+            }
+        }
 
-		    //Run the inference processor on the SADL resource and model
-		    inferenceProcessor.runInference(sadlResource, sadlModel.getAbsolutePath(), owlModelDirectory.getAbsolutePath(), sadlPreferences);
- 		} catch (Exception e) {
-			logger.error("Error running inference: " + e);
-			return false;
-		}
+        return true;
+    }
 
-		return true;
-	}
+    private void cleanProject() {
+        // If we clean these files first, ExecuteCommand reports errors when building the project:
+        // ERROR com.ge.research.sadl.external.ExternalEmfResource - Error occurred while loading
+        // the resource. URI:platform:/resource/HawkeyeUAV/OwlModels/Components.owl
+        // org.eclipse.emf.ecore.resource.Resource$IOWrappedException: Resource
+        // '/HawkeyeUAV/OwlModels/Components.owl' does not exist.
+        //
+        // if (this.owlModelDirectory.exists()) {
+        //     File[] files = this.owlModelDirectory.listFiles();
+        //     for (File file : files) {
+        //         if (!file.getName().equals(configurationRdfFileName) &&
+        //                 !file.getName().equals(ontPolicyRdfFileName)) {
+        //             file.delete();
+        //         }
+        //     }
+        // }
+    }
 
-	private String replaceExtension(String fileName, String newExtension) {
-	    int lastDot = fileName.lastIndexOf(".");
-	    if (lastDot != -1) {
-	        return fileName.substring(0, lastDot) + newExtension;
-	    } else {
-	        return fileName + newExtension;
-	    }
-	}
+    private boolean runInference() {
+        try {
+            // Open the requested SADL resource within the newly imported project
+            final File runInferenceFile = new File(this.importDirectory, this.runInferenceFilePath);
+            final XtextResource sadlResource =
+                    (XtextResource)
+                            resourceSet.getResource(
+                                    URI.createFileURI(runInferenceFile.getAbsolutePath()), true);
 
-	private void createImplicitResources() {
-		//Check for and possibly create implicit model
-		String implicitModelPath = this.importDirectory.getAbsolutePath() + "/" +
-				SadlConstants.SADL_IMPLICIT_MODEL_FOLDER + "/" +
-				SadlConstants.SADL_IMPLICIT_MODEL_FILENAME;
-		File implicitModel = new File(implicitModelPath);
-		if(!implicitModel.exists()){
-			new ISadlImplicitModelContentProvider.Default().createImplicitModel(implicitModel, true);
-		}
-		//Create built-in function model
-		try {
-			JenaBasedSadlModelProcessor.createBuiltinFunctionImplicitModel(this.importDirectory.getAbsolutePath());
-		} catch (Exception e) {
-			logger.error("Error creating SadlBuiltinFunctions.sadl: " + e);
-		}
-	}
+            // Hand off the job to the run inference handler.
+            final SadlRunInferenceHandler runInferenceHandler =
+                    injector.getInstance(SadlRunInferenceHandler.class);
+            final Supplier<XtextResource> resourceSupplier = () -> sadlResource;
+            runInferenceHandler.run(runInferenceFile.toPath(), resourceSupplier, sadlPreferences);
+        } catch (Exception e) {
+            logger.error("Error running inference: " + e);
+            return false;
+        }
 
-	private ArrayList<File> obtainFiles(File rootDirectory, ArrayList<File> fileList, String fileExtension) throws NullPointerException {
-		for(File file : rootDirectory.listFiles()){
-			if(file.isDirectory()){
-				obtainFiles(file, fileList, fileExtension);
-			}
-			else if(file.isFile()){
-				if(file.getAbsolutePath().endsWith(fileExtension)){
-					fileList.add(file);
-				}
-			}
-		}
+        return true;
+    }
 
-		return fileList;
-	}
+    private void createImplicitResources() {
+        // Check for and possibly create implicit model
+        String implicitModelPath =
+                this.importDirectory.getAbsolutePath()
+                        + "/"
+                        + SadlConstants.SADL_IMPLICIT_MODEL_FOLDER
+                        + "/"
+                        + SadlConstants.SADL_IMPLICIT_MODEL_FILENAME;
+        File implicitModel = new File(implicitModelPath);
+        if (!implicitModel.exists()) {
+            new ISadlImplicitModelContentProvider.Default()
+                    .createImplicitModel(implicitModel, true);
+        }
+        // Create built-in function model
+        try {
+            JenaBasedSadlModelProcessor.createBuiltinFunctionImplicitModel(
+                    this.importDirectory.getAbsolutePath());
+        } catch (Exception e) {
+            logger.error("Error creating SadlBuiltinFunctions.sadl: " + e);
+        }
+    }
 
-	private void directWrite(Resource resource){
-		URI resourceUri = ((XtextResource) resource).getURI();
-		logger.info("Building " + resourceUri);
+    private ArrayList<File> obtainFiles(
+            File rootDirectory, ArrayList<File> fileList, String fileExtension)
+            throws NullPointerException {
+        for (File file : rootDirectory.listFiles()) {
+            if (file.isDirectory()) {
+                obtainFiles(file, fileList, fileExtension);
+            } else if (file.isFile()) {
+                if (file.getAbsolutePath().endsWith(fileExtension)) {
+                    fileList.add(file);
+                }
+            }
+        }
 
-		//Validation
-		IResourceValidator validator = ((XtextResource) resource).getResourceServiceProvider().getResourceValidator();
-		validator.validate(resource, CheckMode.NORMAL_AND_FAST, CancelIndicator.NullImpl);
+        return fileList;
+    }
 
-		//Generation
-		GeneratorDelegate generator = null;
-		JavaIoFileSystemAccess access = null;
-		GeneratorContext context = new GeneratorContext();
-		context.setCancelIndicator(CancelIndicator.NullImpl);
-		generator = ((XtextResource) resource).getResourceServiceProvider().get(GeneratorDelegate.class);
-		access = ((XtextResource) resource).getResourceServiceProvider().get(JavaIoFileSystemAccess.class);
-		access.setOutputPath(owlModelDirectory.getAbsolutePath());
-		generator.generate(resource, access, context);
-	}
+    private void directWrite(Resource resource) {
+        URI resourceUri = ((XtextResource) resource).getURI();
+        logger.info("Building " + resourceUri);
 
+        // Validation
+        IResourceValidator validator =
+                ((XtextResource) resource).getResourceServiceProvider().getResourceValidator();
+        validator.validate(resource, CheckMode.NORMAL_AND_FAST, CancelIndicator.NullImpl);
+
+        // Generation
+        GeneratorDelegate generator = null;
+        JavaIoFileSystemAccess access = null;
+        GeneratorContext context = new GeneratorContext();
+        context.setCancelIndicator(CancelIndicator.NullImpl);
+        generator =
+                ((XtextResource) resource)
+                        .getResourceServiceProvider()
+                        .get(GeneratorDelegate.class);
+        access =
+                ((XtextResource) resource)
+                        .getResourceServiceProvider()
+                        .get(JavaIoFileSystemAccess.class);
+        access.setOutputPath(owlModelDirectory.getAbsolutePath());
+        generator.generate(resource, access, context);
+    }
 }

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.applications/src/com/ge/research/sadl/applications/ExecuteCommand.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.applications/src/com/ge/research/sadl/applications/ExecuteCommand.java
@@ -59,7 +59,7 @@ import org.w3c.dom.NodeList;
 public class ExecuteCommand implements IApplication {
 
     // Logger to print what we do
-    private Logger logger = LoggerFactory.getLogger(ExecuteCommand.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExecuteCommand.class);
 
     // Default Configuration file location
     private String configFilePath = "SadlConfiguration.xml";
@@ -155,7 +155,7 @@ public class ExecuteCommand implements IApplication {
         // Create Resources from sadl/sreq files and initiate Direct-Write
         if (inferFlag) {
             if (!importAndBuildSadlProject()) {
-                logger.error("Failure on import and build of SADL Project");
+                LOGGER.error("Failure on import and build of SADL Project");
                 return null;
             }
         }
@@ -163,7 +163,7 @@ public class ExecuteCommand implements IApplication {
         // Invoke SADL RunInference Tool
         if (inferFlag) {
             if (!runInference()) {
-                logger.error("Failure on inference of SADL file");
+                LOGGER.error("Failure on inference of SADL file");
                 return null;
             }
         }
@@ -172,7 +172,7 @@ public class ExecuteCommand implements IApplication {
         restoreEclipsePreferences();
         refreshWorkspace();
 
-        logger.info("SADL Command-Line Interface complete");
+        LOGGER.info("SADL Command-Line Interface complete");
 
         return IApplication.EXIT_OK;
     }
@@ -197,12 +197,12 @@ public class ExecuteCommand implements IApplication {
                         project.delete(true, true, null);
                         break;
                     } catch (CoreException e) {
-                        logger.error(
+                        LOGGER.error(
                                 "Preexisting project could not be deleted from workspace: " + e);
                         return false;
                     }
                 } else {
-                    logger.error(
+                    LOGGER.error(
                             "This project already exists within the workspace; use the \"-force\" flag to overwrite");
                     return false;
                 }
@@ -220,7 +220,7 @@ public class ExecuteCommand implements IApplication {
             }
             copyDirectory(this.importDirectory.toPath(), lNewProjectPath);
         } catch (IOException e) {
-            logger.error("Unable to copy project into workspace: " + e);
+            LOGGER.error("Unable to copy project into workspace: " + e);
             return false;
         }
 
@@ -234,7 +234,7 @@ public class ExecuteCommand implements IApplication {
             project.create(description, null);
             project.open(null);
         } catch (CoreException e) {
-            logger.error("Unable to import project into workspace: " + e);
+            LOGGER.error("Unable to import project into workspace: " + e);
             return false;
         }
 
@@ -256,7 +256,7 @@ public class ExecuteCommand implements IApplication {
         try {
             Files.copy(aSource, aDestination, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
         } catch (IOException e) {
-            logger.error("Unable to copy file to workspace: " + aSource);
+            LOGGER.error("Unable to copy file to workspace: " + aSource);
         }
     }
 
@@ -271,7 +271,7 @@ public class ExecuteCommand implements IApplication {
                     try {
                         project.open(null);
                     } catch (CoreException e) {
-                        logger.error(
+                        LOGGER.error(
                                 projectName
                                         + " cannot be opened through this interface. Please open project within SADL GUI and execute again.");
                         return false;
@@ -281,7 +281,7 @@ public class ExecuteCommand implements IApplication {
             }
         }
 
-        logger.error(
+        LOGGER.error(
                 "The project that is attempting to be processed is not part of the current workspace. Please set the correct workspace location within the .cmd file.");
         return false;
     }
@@ -291,7 +291,7 @@ public class ExecuteCommand implements IApplication {
             IWorkspaceRoot workspaceRoot = ResourcesPlugin.getWorkspace().getRoot();
             workspaceRoot.refreshLocal(IResource.DEPTH_INFINITE, null);
         } catch (CoreException e) {
-            logger.error("Error refreshing workspace: " + e);
+            LOGGER.error("Error refreshing workspace: " + e);
         }
         return true;
     }
@@ -306,7 +306,7 @@ public class ExecuteCommand implements IApplication {
         try {
             ep.flush();
         } catch (BackingStoreException e) {
-            logger.error("Error setting Eclipse preferences: " + e);
+            LOGGER.error("Error setting Eclipse preferences: " + e);
         }
     }
 
@@ -318,7 +318,7 @@ public class ExecuteCommand implements IApplication {
         try {
             ep.flush();
         } catch (BackingStoreException e) {
-            logger.error("Error restoring Eclipse preferences: " + e);
+            LOGGER.error("Error restoring Eclipse preferences: " + e);
         }
     }
 
@@ -326,7 +326,7 @@ public class ExecuteCommand implements IApplication {
         // Default location, will be update later to be passed in as argument perhaps
         File configFile = new File(this.configFilePath);
         if (!configFile.exists()) {
-            logger.error("Configuration file " + configFile + " does not exist");
+            LOGGER.error("Configuration file " + configFile + " does not exist");
             return false;
         }
 
@@ -488,7 +488,7 @@ public class ExecuteCommand implements IApplication {
                 }
             }
         } catch (Exception e) {
-            logger.error("Error loading configuration file: " + e);
+            LOGGER.error("Error loading configuration file: " + e);
             return false;
         }
 
@@ -516,11 +516,11 @@ public class ExecuteCommand implements IApplication {
         if (importDirectory != null) {
             this.importDirectory = new File(importDirectory);
             if (!this.importDirectory.isDirectory()) {
-                logger.error("Given directory for -import argument was not valid");
+                LOGGER.error("Given directory for -import argument was not valid");
                 return false;
             }
         } else {
-            logger.error("Argument is missing: -import=[Directory of Project]");
+            LOGGER.error("Argument is missing: -import=[Directory of Project]");
             return false;
         }
 
@@ -531,11 +531,11 @@ public class ExecuteCommand implements IApplication {
         if (runInferenceFilePath != null) {
             this.runInferenceFilePath = runInferenceFilePath;
             if (!new File(this.importDirectory, runInferenceFilePath).canRead()) {
-                logger.error("Given file for -infer argument was not valid");
+                LOGGER.error("Given file for -infer argument was not valid");
                 return false;
             }
         } else {
-            logger.error("Argument is missing: -infer=[File to infer]");
+            LOGGER.error("Argument is missing: -infer=[File to infer]");
             return false;
         }
 
@@ -573,7 +573,7 @@ public class ExecuteCommand implements IApplication {
         preferencesByLanguage.attachToEmfObject(resourceSet);
 
         // build resource sets
-        logger.info("Creating resources in memory");
+        LOGGER.info("Creating resources in memory");
         for (File file : sadlFiles) {
             resourceSet.getResource(URI.createFileURI(file.getAbsolutePath()), true);
         }
@@ -583,7 +583,7 @@ public class ExecuteCommand implements IApplication {
         for (File file : sverFiles) {
             resourceSet.getResource(URI.createFileURI(file.getAbsolutePath()), true);
         }
-        logger.info("Resolving interdependencies between resources");
+        LOGGER.info("Resolving interdependencies between resources");
         EcoreUtil2.resolveAll(resourceSet);
 
         // Direct Write
@@ -637,7 +637,7 @@ public class ExecuteCommand implements IApplication {
             final Supplier<XtextResource> resourceSupplier = () -> sadlResource;
             runInferenceHandler.run(runInferenceFile.toPath(), resourceSupplier, sadlPreferences);
         } catch (Exception e) {
-            logger.error("Error running inference: " + e);
+            LOGGER.error("Error running inference: " + e);
             return false;
         }
 
@@ -662,7 +662,7 @@ public class ExecuteCommand implements IApplication {
             JenaBasedSadlModelProcessor.createBuiltinFunctionImplicitModel(
                     this.importDirectory.getAbsolutePath());
         } catch (Exception e) {
-            logger.error("Error creating SadlBuiltinFunctions.sadl: " + e);
+            LOGGER.error("Error creating SadlBuiltinFunctions.sadl: " + e);
         }
     }
 
@@ -684,7 +684,7 @@ public class ExecuteCommand implements IApplication {
 
     private void directWrite(Resource resource) {
         URI resourceUri = ((XtextResource) resource).getURI();
-        logger.info("Building " + resourceUri);
+        LOGGER.info("Building " + resourceUri);
 
         // Validation
         IResourceValidator validator =

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.applications/src/com/ge/research/sadl/applications/SADLCliAppRuntimeModule.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.applications/src/com/ge/research/sadl/applications/SADLCliAppRuntimeModule.java
@@ -1,30 +1,43 @@
-/************************************************************************
+/**
  * Copyright © 2007-2018 - General Electric Company, All Rights Reserved
- * 
- * Project: SADL
- * 
- * Description: The Semantic Application Design Language (SADL) is a
- * language for building semantic models and expressing rules that
- * capture additional domain knowledge. The SADL-IDE (integrated
- * development environment) is a set of Eclipse plug-ins that
- * support the editing and testing of semantic models using the
- * SADL language.
- * 
- * This software is distributed "AS-IS" without ANY WARRANTIES
- * and licensed under the Eclipse Public License - v 1.0
- * which is available at http://www.eclipse.org/org/documents/epl-v10.php
- * 
- ***********************************************************************/
+ *
+ * <p>Project: SADL
+ *
+ * <p>Description: The Semantic Application Design Language (SADL) is a language for building
+ * semantic models and expressing rules that capture additional domain knowledge. The SADL-IDE
+ * (integrated development environment) is a set of Eclipse plug-ins that support the editing and
+ * testing of semantic models using the SADL language.
+ *
+ * <p>This software is distributed "AS-IS" without ANY WARRANTIES and licensed under the Eclipse
+ * Public License - v 1.0 which is available at http://www.eclipse.org/org/documents/epl-v10.php
+ */
 package com.ge.research.sadl.applications;
 
+import com.ge.research.sadl.SADLRuntimeModule;
+import com.ge.research.sadl.builder.MessageManager;
+import com.ge.research.sadl.ide.handlers.SadlGraphVisualizerHandler;
+import com.ge.research.sadl.ide.utils.SadlIdeProjectHelper;
+import com.ge.research.sadl.model.visualizer.GraphVizVisualizer;
+import com.ge.research.sadl.model.visualizer.IGraphVisualizer;
+import com.ge.research.sadl.reasoner.ResultSet;
+import com.ge.research.sadl.ui.utils.EclipseSadlProjectHelper;
+import com.ge.research.sadl.utils.SadlConsole;
+import com.ge.research.sadl.utils.SadlProjectHelper;
+import com.google.inject.ConfigurationException;
+import com.google.inject.Inject;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.Map;
 import org.eclipse.emf.common.notify.Notifier;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.xtext.builder.clustering.CurrentDescriptions;
 import org.eclipse.xtext.resource.IResourceDescriptions;
 import org.eclipse.xtext.resource.containers.IAllContainersState.Provider;
 import org.eclipse.xtext.resource.containers.ResourceSetBasedAllContainersStateProvider;
-
-import com.ge.research.sadl.SADLRuntimeModule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Customized SADL runtime module that contains a workaround for the
@@ -33,25 +46,121 @@ import com.ge.research.sadl.SADLRuntimeModule;
 @SuppressWarnings("restriction")
 public class SADLCliAppRuntimeModule extends SADLRuntimeModule {
 
-	@Override
-	public Class<? extends Provider> bindIAllContainersState$Provider() {
-		return MyResourceSetBasedAllContainersStateProvider.class; // org.eclipse.xtext.ui.containers.ContainerStateProvider
-	}
+    @Override
+    public Class<? extends Provider> bindIAllContainersState$Provider() {
+        return MyResourceSetBasedAllContainersStateProvider
+                .class; // org.eclipse.xtext.ui.containers.ContainerStateProvider
+    }
 
-	public static class MyResourceSetBasedAllContainersStateProvider extends ResourceSetBasedAllContainersStateProvider
-			implements Provider {
+    public static class MyResourceSetBasedAllContainersStateProvider
+            extends ResourceSetBasedAllContainersStateProvider implements Provider {
 
-		@Override
-		protected ResourceSet getResourceSet(IResourceDescriptions context) {
-			if (context instanceof CurrentDescriptions) {
-				Notifier target = ((CurrentDescriptions) context).getTarget();
-				if (target instanceof ResourceSet) {
-					return (ResourceSet) target;
-				}
-			}
-			return super.getResourceSet(context);
-		}
+        @Override
+        protected ResourceSet getResourceSet(IResourceDescriptions context) {
+            if (context instanceof CurrentDescriptions) {
+                Notifier target = ((CurrentDescriptions) context).getTarget();
+                if (target instanceof ResourceSet) {
+                    return (ResourceSet) target;
+                }
+            }
+            return super.getResourceSet(context);
+        }
+    }
 
-	}
+    public Class<? extends SadlConsole> bindSadlConsole() {
+        return MySadlConsole.class;
+    }
 
+    public static class MySadlConsole implements SadlConsole {
+        private Logger logger = LoggerFactory.getLogger(MySadlConsole.class);
+
+        @Override
+        public void print(final MessageManager.MessageType type, final String message) {
+            switch (type) {
+                case ERROR:
+                    logger.error(message);
+                    break;
+                case WARN:
+                    logger.warn(message);
+                    break;
+                case INFO:
+                    logger.info(message);
+                    break;
+                default:
+                    logger.debug(message);
+                    break;
+            }
+        }
+    }
+
+    public Class<? extends SadlProjectHelper> bindSadlProjectHelper() {
+        return MySadlProjectHelper.class;
+    }
+
+    public static class MySadlProjectHelper implements SadlProjectHelper {
+        private EclipseSadlProjectHelper eclipseHelper = new EclipseSadlProjectHelper();
+        private SadlIdeProjectHelper ideHelper = new SadlIdeProjectHelper();
+
+        private boolean usesFileScheme(final URI uri) {
+            return "file".equalsIgnoreCase(uri.getScheme());
+        }
+
+        @Override
+        public boolean isRoot(final URI uri) {
+            if (usesFileScheme(uri)) {
+                return ideHelper.isRoot(uri);
+            } else {
+                return eclipseHelper.isRoot(uri);
+            }
+        }
+
+        @Override
+        public URI getRoot(final URI nested) {
+            if (usesFileScheme(nested)) {
+                return ideHelper.getRoot(nested);
+            } else {
+                return eclipseHelper.getRoot(nested);
+            }
+        }
+
+        @Override
+        public Path toPath(final URI uri) {
+            if (usesFileScheme(uri)) {
+                return ideHelper.toPath(uri);
+            } else {
+                return eclipseHelper.toPath(uri);
+            }
+        }
+    }
+
+    public Class<? extends SadlGraphVisualizerHandler> bindSadlGraphVisualizerHandler() {
+        return MySadlGraphVisualizerHandler.class;
+    }
+
+    public static class MySadlGraphVisualizerHandler implements SadlGraphVisualizerHandler {
+        @Inject private SadlProjectHelper projectHelper;
+        private IGraphVisualizer visualizer = new GraphVizVisualizer();
+
+        @Override
+        public void resultSetToGraph(
+                final Path path,
+                final ResultSet resultSet,
+                final String description,
+                final String baseFileName,
+                final IGraphVisualizer.Orientation orientation,
+                final Map<String, String> properties)
+                throws ConfigurationException, IOException {
+            File projectDirectory = new File(projectHelper.getRoot(path.toUri()));
+            File graphsDirectory = new File(projectDirectory, "Graphs");
+            graphsDirectory.mkdirs();
+            visualizer.initialize(
+                    graphsDirectory.getAbsolutePath(),
+                    baseFileName,
+                    baseFileName,
+                    null,
+                    orientation,
+                    description);
+            visualizer.graphResultSetData(resultSet);
+        }
+    }
 }

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.applications/src/com/ge/research/sadl/applications/SADLCliAppRuntimeModule.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.applications/src/com/ge/research/sadl/applications/SADLCliAppRuntimeModule.java
@@ -72,22 +72,22 @@ public class SADLCliAppRuntimeModule extends SADLRuntimeModule {
     }
 
     public static class MySadlConsole implements SadlConsole {
-        private Logger logger = LoggerFactory.getLogger(MySadlConsole.class);
+        private static final Logger LOGGER = LoggerFactory.getLogger(MySadlConsole.class);
 
         @Override
         public void print(final MessageManager.MessageType type, final String message) {
             switch (type) {
                 case ERROR:
-                    logger.error(message);
+                    LOGGER.error(message);
                     break;
                 case WARN:
-                    logger.warn(message);
+                    LOGGER.warn(message);
                     break;
                 case INFO:
-                    logger.info(message);
+                    LOGGER.info(message);
                     break;
                 default:
-                    logger.debug(message);
+                    LOGGER.debug(message);
                     break;
             }
         }

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.applications/src/com/ge/research/sadl/applications/SADLCliAppStandaloneSetup.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.applications/src/com/ge/research/sadl/applications/SADLCliAppStandaloneSetup.java
@@ -1,20 +1,16 @@
-/************************************************************************
+/**
  * Copyright © 2007-2018 - General Electric Company, All Rights Reserved
- * 
- * Project: SADL
- * 
- * Description: The Semantic Application Design Language (SADL) is a
- * language for building semantic models and expressing rules that
- * capture additional domain knowledge. The SADL-IDE (integrated
- * development environment) is a set of Eclipse plug-ins that
- * support the editing and testing of semantic models using the
- * SADL language.
- * 
- * This software is distributed "AS-IS" without ANY WARRANTIES
- * and licensed under the Eclipse Public License - v 1.0
- * which is available at http://www.eclipse.org/org/documents/epl-v10.php
- * 
- ***********************************************************************/
+ *
+ * <p>Project: SADL
+ *
+ * <p>Description: The Semantic Application Design Language (SADL) is a language for building
+ * semantic models and expressing rules that capture additional domain knowledge. The SADL-IDE
+ * (integrated development environment) is a set of Eclipse plug-ins that support the editing and
+ * testing of semantic models using the SADL language.
+ *
+ * <p>This software is distributed "AS-IS" without ANY WARRANTIES and licensed under the Eclipse
+ * Public License - v 1.0 which is available at http://www.eclipse.org/org/documents/epl-v10.php
+ */
 package com.ge.research.sadl.applications;
 
 import com.ge.research.sadl.SADLStandaloneSetup;
@@ -23,18 +19,14 @@ import com.google.inject.Injector;
 
 /**
  * Standalone setup for the headless CLI application.
- * 
- * <p>
- * This is a workaround for
- * https://github.com/crapo/sadlos2/issues/353#issuecomment-448272712. We cannot
- * use standalone setup when an Eclipse platform is up an running.
  *
+ * <p>This is a workaround for https://github.com/crapo/sadlos2/issues/353#issuecomment-448272712.
+ * We cannot use standalone setup when an Eclipse platform is up an running.
  */
 public class SADLCliAppStandaloneSetup extends SADLStandaloneSetup {
 
-	@Override
-	public Injector createInjector() {
-		return Guice.createInjector(new SADLCliAppRuntimeModule());
-	}
-
+    @Override
+    public Injector createInjector() {
+        return Guice.createInjector(new SADLCliAppRuntimeModule());
+    }
 }

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ide/META-INF/MANIFEST.MF
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ide/META-INF/MANIFEST.MF
@@ -23,6 +23,7 @@ Export-Package: com.ge.research.sadl.ide,
  com.ge.research.sadl.ide.contentassist.antlr.lexer,
  com.ge.research.sadl.ide.contentassist.antlr.lexer.jflex,
  com.ge.research.sadl.ide.editor.contentassist,
- com.ge.research.sadl.ide.handlers
+ com.ge.research.sadl.ide.handlers,
+ com.ge.research.sadl.ide.utils
 Import-Package: org.slf4j
 Automatic-Module-Name: com.ge.research.sadl.ide

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.reasoner-impl/src/main/java/com/ge/research/sadl/model/visualizer/GraphVizVisualizer.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.reasoner-impl/src/main/java/com/ge/research/sadl/model/visualizer/GraphVizVisualizer.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
 
 public class GraphVizVisualizer implements IGraphVisualizer {
 	
-	private final Logger logger = LoggerFactory.getLogger(GraphVizVisualizer.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(GraphVizVisualizer.class);
 	private String tempFolder = null;
 	private String baseFileName = null;
 	private String graphName = null;
@@ -72,7 +72,7 @@ public class GraphVizVisualizer implements IGraphVisualizer {
 			while (mitr.hasNext()) {
 				String key = mitr.next();
 				String val = map.get(key);
-				logger.debug(key + " -> " + val);
+				LOGGER.debug(key + " -> " + val);
 			}
 		}
 		if (exec == null || exec.length() == 0) {
@@ -105,7 +105,7 @@ public class GraphVizVisualizer implements IGraphVisualizer {
 			} catch (IOException e) {
 				throw new IOException("Unable to run GraphViz dot to generate PNG file; is GraphViz path set properly? (" + e.getMessage() + ")");
 			} catch (InterruptedException e) {
-				logger.error("Ignoring " + e, e);
+				LOGGER.error("Ignoring " + e, e);
 			}
 			int cntr = 0;
 			File fto = new File(graphFileToOpen);
@@ -113,7 +113,7 @@ public class GraphVizVisualizer implements IGraphVisualizer {
 				try {
 					Thread.sleep(200);
 				} catch (InterruptedException e) {
-					logger.error("Ignoring " + e, e);
+					LOGGER.error("Ignoring " + e, e);
 				}
 			}
 			if (!fto.exists()) {

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.reasoner-impl/src/main/java/com/ge/research/sadl/model/visualizer/GraphVizVisualizer.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.reasoner-impl/src/main/java/com/ge/research/sadl/model/visualizer/GraphVizVisualizer.java
@@ -13,660 +13,658 @@ import javax.activation.DataSource;
 import com.ge.research.sadl.reasoner.ResultSet;
 import com.ge.research.sadl.reasoner.utils.SadlUtils;
 import com.hp.hpl.jena.vocabulary.OWL;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class GraphVizVisualizer implements IGraphVisualizer {
-	
-	private String tempFolder = null;
-	private String baseFileName = null;
-	private String graphName = null;
-	private String anchorNode = null;
-	private Orientation orientation = null;
-	private String description = null;
-	
-	private String graphFileToOpen = null;
-	private int nothingCount;
-	private HashMap<String,String> graphedSubjectMap;
-	private HashMap<String,String> duplicateObjectMap;
-	private StringBuilder sb;
-	private boolean repeatObjNode;
-	private boolean repeatSubjNode;
-	private List<String> nodes;
-	private HashMap<Object, List<Object[]>> subjectList;
-	private HashMap<Object, List<Object[]>> objectList;
 
-	@Override
-	public void initialize(String tempDir, String bfn, String graphName, String anchorNode, Orientation orientation, String description) {
-		setTempFolder(tempDir);
-		setBaseFileName(bfn);
-		setGraphName(graphName);
-		setAnchorNode(anchorNode);
-		setOrientation(orientation);
-		setDescription(description);
-	}
-	
-	@Override
-	public List<String> graphCsvData(String csvFilepath) throws IOException {
-		throw new IOException("Method graphCsvData(String filepath) not yet implemented");
-	}
+    private final Logger logger = LoggerFactory.getLogger(GraphVizVisualizer.class);
+    private String tempFolder = null;
+    private String baseFileName = null;
+    private String graphName = null;
+    private String anchorNode = null;
+    private Orientation orientation = null;
+    private String description = null;
 
-	@Override
-	public List<String> graphCsvData(DataSource ds) throws IOException {
-		throw new IOException("Method graphCsvData(DataSource ds) not yet implemented");
-	}
+    private String graphFileToOpen = null;
+    private int nothingCount;
+    private HashMap<String,String> graphedSubjectMap;
+    private HashMap<String,String> duplicateObjectMap;
+    private StringBuilder sb;
+    private boolean repeatObjNode;
+    private boolean repeatSubjNode;
+    private List<String> nodes;
+    private HashMap<Object, List<Object[]>> subjectList;
+    private HashMap<Object, List<Object[]>> objectList;
 
-	@Override
-	public List<String> graphResultSetData(ResultSet rs) throws IOException {
-		File dotFile = constructResultSetToDotFile(rs, new File(getTempFolder()), getBaseFileName(), getGraphName(), getAnchorNode(), getDescription(), getOrientation());
-		createGraphVizGraph(dotFile.getCanonicalPath());
-		return null;
-	}
+    @Override
+    public void initialize(String tempDir, String bfn, String graphName, String anchorNode, Orientation orientation, String description) {
+        setTempFolder(tempDir);
+        setBaseFileName(bfn);
+        setGraphName(graphName);
+        setAnchorNode(anchorNode);
+        setOrientation(orientation);
+        setDescription(description);
+    }
 
-	public void createGraphVizGraph(String dotfilepath) throws IOException {
-		String exec = System.getenv("GraphVizPath");
-		if (exec == null) {
-			Map<String, String> map = System.getenv();
-			Iterator<String> mitr = map.keySet().iterator();
-			while (mitr.hasNext()) {
-				String key = mitr.next();
-				String val = map.get(key);
-				System.out.println(key + " -> " + val);
-			}
-		}
-		if (exec == null || exec.length() == 0) {
-			throw new IOException("Unable to find GraphVizPath. Please set GraphVizPath environment variable to the GraphViz bin folder path.");
-		}
-    	String dotexec = null;
-    	if (!exec.endsWith("dotty") && !exec.endsWith("dotty.exe")) {
-    		dotexec = exec + File.separator + "dot";
-    		exec = exec + File.separator + "dotty";
-    	}
-		if (dotexec != null) {
-			// dot -Tps filename.dot -o outfile.ps
-			String svgfilepath = dotfilepath;
-			if (dotfilepath.endsWith(".dot")) {
-				svgfilepath = dotfilepath.substring(0, dotfilepath.length() - 4);
-			}
-			String svgfn = svgfilepath + getGraphFilenameExtension();
-			File f = new File(svgfn);
-			if (f.exists()) {
-				boolean status = f.delete();
-				if (!status) {
-					throw new IOException("Unable to delete existing file '" + svgfn + "'.");
-				}
-			}
-			ProcessBuilder bppng = new ProcessBuilder(dotexec, "-Tsvg", dotfilepath,"-o", svgfn);
-			try {
-				bppng.start();
-				Thread.sleep(100);
-				graphFileToOpen = svgfn;
-			} catch (IOException e) {
-				throw new IOException("Unable to run GraphViz dot to generate PNG file; is GraphViz path set properly? (" + e.getMessage() + ")");
-			} catch (InterruptedException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			}
-			int cntr = 0;
-			File fto = new File(graphFileToOpen);
-			while (cntr++ < 50 && !fto.exists()) {
-				try {
-					Thread.sleep(200);
-				} catch (InterruptedException e) {
-					// TODO Auto-generated catch block
-					e.printStackTrace();
-				}
-			}
-			if (!fto.exists()) {
-				ProcessBuilder pb = new ProcessBuilder(exec, dotfilepath);
-				try {
-					pb.start();
-				} catch (IOException e2) {
-					throw new IOException("Unable to run GraphViz dotty; is GraphViz installed and on path? (" + e2.getMessage() + ")");
-				}
-			}
-			else {
-				String dontdelete = System.getenv("GraphVizKeepDot");
-				if (dontdelete == null || !dontdelete.equalsIgnoreCase("true")) {
-					// delete the .dot file
-					File dotfile = new File(dotfilepath);
-					if (dotfile.exists()) {
-						dotfile.delete();
-					}
-				}
-			}
-		}
-	}
+    @Override
+    public List<String> graphCsvData(String csvFilepath) throws IOException {
+        throw new IOException("Method graphCsvData(String filepath) not yet implemented");
+    }
 
-	/**
-	 * Method to create a GraphViz .dot file from a construct ResultSet
-	 * @param rs
-	 * @param tmpdir
-	 * @param bfn -- base file name to use for output file
-	 * @param anchorNodeName -- 
-	 * @param anchorNodeLabel -- the node which is the anchor (colored differently)
-	 * @param description
-	 * @param orientation
-	 * @return
-	 * @throws IOException
-	 */
-	public File constructResultSetToDotFile(ResultSet rs, File tmpdir, String bfn, String anchorNodeName, String anchorNodeLabel, String description, Orientation orientation) throws IOException {
-		Map<Integer,String> headAttributes = null;
-		Map<Integer,String> edgeAttributes = null;
-		Map<Integer,String> tailAttributes = null;
-		if (rs.getColumnCount() > 3) {
-			String[] headers = rs.getColumnNames();
-			String headName = headers[0];
-			String edgeName = headers[1];
-			String tailName = headers[2];
-			for (int i = 3; i < headers.length; i++) {
-				String attrHeader = headers[i];
-				if (attrHeader.startsWith(headName)) {
-					headAttributes = addAttribute(headAttributes, headName, i, attrHeader);
-				}
-				else if (attrHeader.startsWith(edgeName)) {
-					edgeAttributes = addAttribute(edgeAttributes, edgeName, i, attrHeader);
-				}
-				else if (attrHeader.startsWith(tailName)) {
-					tailAttributes = addAttribute(tailAttributes, tailName, i, attrHeader);
-				}
-				else {
-					throw new IOException("Column " + (i + 1) + " header '" + headers[i] + "' does not begin with a valid identifier from the first 3 headers: '" + headName + "' or '" + edgeName + "' or '" + tailName + "')");
-				}
-			}
-			
-		}
-		sb = new StringBuilder("digraph g");
-		sb.append(anchorNodeName);
-		sb.append(" {\n");
-		if (orientation != null && orientation != Orientation.TD){
-			sb.append("   rankdir=");
-			sb.append(orientation.toString());
-			sb.append("\n");
-		}
-		nodes = new ArrayList<String>();
-		sb.append("    label=\"");
-		if (description != null) {
-			sb.append(description);
-		}
-		else {
-			sb.append("Construct ");
-			sb.append(anchorNodeName + 1);
-		}
-		sb.append("\";\n    labelloc=top;\n    labeljust=left;\n");
-		
-		nothingCount = 0;
-		graphedSubjectMap = null;
-		duplicateObjectMap = null;
-		
-		subjectList = new HashMap<Object, List<Object[]>>();
-		objectList = new HashMap<Object, List<Object[]>>();
-		while (rs.hasNext()) {
-			Object[] row = rs.next();
-			if (row[0] != null) {
-				addRowToMap(subjectList, rs.getShowNamespaces() ? row[0] : rs.extractLocalName(row[0]), row);
-//				subjectList.add(rs.getShowNamespaces() ? row[0] : rs.extractLocalName(row[0]));
-			}
-			if (row[2] != null) {
-				addRowToMap(objectList, rs.getShowNamespaces() ? row[2] : rs.extractLocalName(row[2]), row);
-//				objectList.add(rs.getShowNamespaces() ? row[2] : rs.extractLocalName(row[2]));
-			}
-		}
-		rs.first();	// reset cursor
-		
-		while (rs.hasNext()) {
-			Object[] row = rs.next();
-			String slbl;			// name of start of directed edge
-			String olbl;			// name of end of directed edge
-			Object s;
-			//If this is a single node to be graphed
-			if(row[0] != null && row[1] == null && row[2] == null){
-				//is a single node
-				if (row[0].equals(OWL.Nothing.getURI())) {
-					s = OWL.Nothing;
-					slbl = OWL.Nothing.getLocalName() + nothingCount;
-					nothingCount++;
-					repeatSubjNode = false;
-				}
-				else {
-					s = rs.getShowNamespaces() ? row[0] : rs.extractLocalName(row[0]);
-					if (!nodes.contains(s.toString())) {
-						nodes.add(s.toString());
-						slbl = "n" + nodes.size();
-						repeatSubjNode = false;
-					}
-					else {
-						slbl = "n" + (nodes.indexOf(s.toString()) + 1);
-						repeatSubjNode = true;
-					}
-				}
-				sb.append("     ");
-				if (!repeatSubjNode) {
-					sb.append(slbl);
-					if(s.equals(OWL.Nothing)) {
-						sb.append("[shape=point label=\"");
-					}
-					else {
-						sb.append("[shape=box label=\"");
-					}
-					sb.append(s.toString());
-					sb.append("\"");
-					boolean anchored = false;
-					if (anchorNodeLabel != null && s.toString().equals(anchorNodeLabel)) {
-						anchored = true;
-					}
-					applyAttributesToNode(headAttributes, row, anchored);
-					sb.append("];\n");
-				}
+    @Override
+    public List<String> graphCsvData(DataSource ds) throws IOException {
+        throw new IOException("Method graphCsvData(DataSource ds) not yet implemented");
+    }
 
-				continue;
-				
-			}else if (row[0] == null && row[1] == null && row[2] == null) {
-				continue;
-			}
-			
-			s = rs.getShowNamespaces() ? row[0] : rs.extractLocalName(row[0]);
-			String edgeLbl = rs.getShowNamespaces() ? row[1].toString() : rs.extractLocalName(row[1]);
-			Object o = rs.getShowNamespaces() ? row[2] : rs.extractLocalName(row[2]);
+    @Override
+    public List<String> graphResultSetData(ResultSet rs) throws IOException {
+        File dotFile = constructResultSetToDotFile(rs, new File(getTempFolder()), getBaseFileName(), getGraphName(), getAnchorNode(), getDescription(), getOrientation());
+        createGraphVizGraph(dotFile.getCanonicalPath());
+        return null;
+    }
 
-			createGraphTriple(s, edgeLbl, o, headAttributes, edgeAttributes, tailAttributes, row, anchorNodeLabel, null);
-		}
-		if (duplicateObjectMap != null) {
-			Iterator<String> objitr = duplicateObjectMap.keySet().iterator();
-			while (objitr.hasNext()) {
-				String key = objitr.next();
-				String objnm = duplicateObjectMap.get(key);
-				if (graphedSubjectMap != null && graphedSubjectMap.containsValue(objnm) && !graphedSubjectMap.containsKey(key)) {
-					// we need to fill out missing branches
-//					System.out.println("need to fill out branch of '" + objnm + "' from specific object node '" + key + "'");
-					rs.first();
-					while (rs.hasNext()) {
-						Object[] row = rs.next();
-						if (row[0].equals(objnm)) {
-							Object s = rs.getShowNamespaces() ? row[0] : rs.extractLocalName(row[0]);
-							String edgeLbl = rs.getShowNamespaces() ? row[1].toString() : rs.extractLocalName(row[1]);
-							Object o = rs.getShowNamespaces() ? row[2] : rs.extractLocalName(row[2]);
-							createGraphTriple(s, edgeLbl, o, headAttributes, edgeAttributes, tailAttributes, row, anchorNodeLabel, key);
-						}
-					}
-				}
-			}
-		}
-		sb.append("}\n");
-//		System.out.println(sb.toString());
-		File dotFile = new java.io.File(tmpdir.getAbsolutePath() + File.separator + 
-				((bfn != null ? bfn : "") + ".dot"));
-		new SadlUtils().stringToFile(dotFile, sb.toString(), false);
-		return dotFile;
-	}
-	
-	private void addRowToMap(HashMap<Object, List<Object[]>> list, Object key, Object[] row) {
-		if (list.containsKey(key)) {
-			list.get(key).add(row);
-		}
-		else {
-			List<Object[]> valList = new ArrayList<Object[]>();
-			valList.add(row);
-			list.put(key, valList);
-		}	
-	}
+    public void createGraphVizGraph(String dotfilepath) throws IOException {
+        String exec = System.getenv("GraphVizPath");
+        if (exec == null) {
+            Map<String, String> map = System.getenv();
+            Iterator<String> mitr = map.keySet().iterator();
+            while (mitr.hasNext()) {
+                String key = mitr.next();
+                String val = map.get(key);
+                logger.debug(key + " -> " + val);
+            }
+        }
+        if (exec == null || exec.length() == 0) {
+            throw new IOException("Unable to find GraphVizPath. Please set GraphVizPath environment variable to the GraphViz bin folder path.");
+        }
+        String dotexec = null;
+        if (!exec.endsWith("dotty") && !exec.endsWith("dotty.exe")) {
+            dotexec = exec + File.separator + "dot";
+            exec = exec + File.separator + "dotty";
+        }
+        if (dotexec != null) {
+            // dot -Tps filename.dot -o outfile.ps
+            String svgfilepath = dotfilepath;
+            if (dotfilepath.endsWith(".dot")) {
+                svgfilepath = dotfilepath.substring(0, dotfilepath.length() - 4);
+            }
+            String svgfn = svgfilepath + getGraphFilenameExtension();
+            File f = new File(svgfn);
+            if (f.exists()) {
+                boolean status = f.delete();
+                if (!status) {
+                    throw new IOException("Unable to delete existing file '" + svgfn + "'.");
+                }
+            }
+            ProcessBuilder bppng = new ProcessBuilder(dotexec, "-Tsvg", dotfilepath,"-o", svgfn);
+            try {
+                bppng.start();
+                Thread.sleep(100);
+                graphFileToOpen = svgfn;
+            } catch (IOException e) {
+                throw new IOException("Unable to run GraphViz dot to generate PNG file; is GraphViz path set properly? (" + e.getMessage() + ")");
+            } catch (InterruptedException e) {
+                logger.error("Ignoring " + e, e);
+            }
+            int cntr = 0;
+            File fto = new File(graphFileToOpen);
+            while (cntr++ < 50 && !fto.exists()) {
+                try {
+                    Thread.sleep(200);
+                } catch (InterruptedException e) {
+                    logger.error("Ignoring " + e, e);
+                }
+            }
+            if (!fto.exists()) {
+                ProcessBuilder pb = new ProcessBuilder(exec, dotfilepath);
+                try {
+                    pb.start();
+                } catch (IOException e2) {
+                    throw new IOException("Unable to run GraphViz dotty; is GraphViz installed and on path? (" + e2.getMessage() + ")");
+                }
+            }
+            else {
+                String dontdelete = System.getenv("GraphVizKeepDot");
+                if (dontdelete == null || !dontdelete.equalsIgnoreCase("true")) {
+                    // delete the .dot file
+                    File dotfile = new File(dotfilepath);
+                    if (dotfile.exists()) {
+                        dotfile.delete();
+                    }
+                }
+            }
+        }
+    }
 
-	private void createGraphTriple(Object s, String edgeLbl, Object o, Map<Integer, String> headAttributes, Map<Integer, String> edgeAttributes, Map<Integer, 
-			String> tailAttributes, Object[] row, String anchorNodeLabel, String subjectNode) {
-		String slbl = subjectNode;
-		String olbl;
-		if (slbl == null) {
-			if (row[0].equals(OWL.Nothing.getURI())) {
-				s = OWL.Nothing;
-				slbl = OWL.Nothing.getLocalName() + nothingCount;
-				nothingCount++;
-				repeatSubjNode = false;
-			}
-			else {
-				//check if this node should be duplicated: Used in graphing context AATIM-1389
-				boolean duplicateNode = getDuplicateAttribute(headAttributes, row);
-				long headSequenceNum = getSequenceNumber(headAttributes, row);
-				if (duplicateNode || headSequenceNum > 0) {
-					//don't check to see if this node is in nodes
-					nodes.add(s.toString());
-					if (headSequenceNum > 0) {
-						slbl = "n" + headSequenceNum;
-					}
-					else {
-						slbl = "n" + nodes.size();
-					}
-					repeatSubjNode = false;
-				}else if (!nodes.contains(s.toString())) {
-					nodes.add(s.toString());
-					slbl = "n" + nodes.size();
-					repeatSubjNode = false;
-				}
-				else {
-					slbl = "n" + (nodes.indexOf(s.toString()) + 1);
-					repeatSubjNode = true;
-				}
-				if (graphedSubjectMap == null) {
-					graphedSubjectMap = new HashMap<String,String>();
-				}
-				graphedSubjectMap.put(slbl, s.toString());
-			}
-		}
-		else {
-			repeatSubjNode = true;
-		}
-		if (row[2] != null && row[2].equals(OWL.Nothing.getURI())) {
-			o = OWL.Nothing;
-			olbl = OWL.Nothing.getLocalName() + nothingCount;
-			nothingCount++;
-			repeatObjNode = false;
-		}
-		else {
-			//check if this node should be duplicated: Used in graphing context AATIM-1389
-			boolean duplicateNode = getDuplicateAttribute(tailAttributes, row);
-			long tailSequenceNum = getSequenceNumber(tailAttributes, row);
-			if(duplicateNode || tailSequenceNum > 0){
-				//don't check to see if this node is in nodes
-				nodes.add(o.toString());
-				if (tailSequenceNum > 0) {
-					olbl = "n" + tailSequenceNum;
-				}
-				else {
-					olbl = "n" + nodes.size();
-				}
-				repeatObjNode = false;
-				if (subjectNode == null && repeatSubjNode) {
-					// now we want to expand out any children that this duplicate should have so it continues what's in the data...
-					if (duplicateObjectMap == null) {
-						duplicateObjectMap = new HashMap<String,String>();
-					}
-					duplicateObjectMap.put(olbl, o.toString());
-				}
-			}else if (!nodes.contains(o.toString())) {
-				nodes.add(o.toString());
-				olbl = "n" + nodes.size();
-				repeatObjNode = false;
-			}
-			else {
-				olbl = "n" + (nodes.indexOf(o.toString()) + 1);
-				repeatObjNode = true;
-			}
-		}
-		sb.append("     ");
-		if (!repeatSubjNode) {
-			sb.append(slbl);
-			if(s.equals(OWL.Nothing)) {
-				sb.append("[shape=point label=\"");
-			}
-			else {
-				sb.append("[shape=box label=\"");
-			}
-			sb.append(replaceDoubleQuotes(s.toString()));
-			sb.append("\"");
-			boolean anchored = false;
-			if (anchorNodeLabel != null && s.toString().equals(anchorNodeLabel)) {
-				anchored = true;
-			}
-			applyAttributesToNode(headAttributes, row, anchored);
-			if (objectList.containsKey(s)) {
-				List<Object[]> valList = objectList.get(s);
-				for (int i = 0; i < valList.size(); i++) {
-					applyAttributesToNode(tailAttributes, valList.get(i), anchored);
-				}
-			}
-			sb.append("];\n");
-		}
-		if (!repeatObjNode) {
-			sb.append("     ");
-			sb.append(olbl);
-			if (o.equals(OWL.Nothing)) {
-				sb.append("[shape=point label=\"");
-			}
-			else {
-				sb.append("[shape=box label=\"");
-			}
-			sb.append(replaceDoubleQuotes(o.toString()));
-			sb.append("\"");
-			boolean anchored = false;
-			if (anchorNodeLabel != null && o.toString().equals(anchorNodeLabel)) {
-				anchored = true;
-			}
-			applyAttributesToNode(tailAttributes, row, anchored);
-			if (subjectList.containsKey(o)) {
-				List<Object[]> valList = subjectList.get(o);
-				for (int i = 0; i < valList.size(); i++) {
-					applyAttributesToNode(headAttributes, valList.get(i), anchored);
-				}
-			}
-			sb.append("];\n");
-		}
-		sb.append("     ");
-		sb.append(slbl);
-		sb.append("->");
-		sb.append(olbl);
-		sb.append("[");
-		boolean anchored = false;
-		if (row[1] != null && row[1].toString().length() > 0) {
-			if (anchorNodeLabel != null && edgeLbl.equals(anchorNodeLabel)) {
-				anchored = true;
-			}
-			sb.append("label=\"");
-			sb.append(replaceDoubleQuotes(edgeLbl));
-			sb.append("\"");
-			// color the "anchor" edge
-			if (anchored) {
-				sb.append(" style=bold");
-			}
-		}
-		if (edgeAttributes != null) {
-			Iterator<Integer> itr = edgeAttributes.keySet().iterator();
-			while (itr.hasNext()) {
-				Integer key = itr.next();
-				String value = edgeAttributes.get(key);
-				if (anchored && value.equals("style")) {
-					continue; // already set
-				}
-				if (row[key.intValue()] != null) {
-					sb.append(" ");
-					sb.append(value);
-					sb.append("=");
-					sb.append(row[key.intValue()]);
-				}
-			}
-		}
-		sb.append("];\n");
-	}
+    /**
+     * Method to create a GraphViz .dot file from a construct ResultSet
+     * @param rs
+     * @param tmpdir
+     * @param bfn -- base file name to use for output file
+     * @param anchorNodeName --
+     * @param anchorNodeLabel -- the node which is the anchor (colored differently)
+     * @param description
+     * @param orientation
+     * @return
+     * @throws IOException
+     */
+    public File constructResultSetToDotFile(ResultSet rs, File tmpdir, String bfn, String anchorNodeName, String anchorNodeLabel, String description, Orientation orientation) throws IOException {
+        Map<Integer,String> headAttributes = null;
+        Map<Integer,String> edgeAttributes = null;
+        Map<Integer,String> tailAttributes = null;
+        if (rs.getColumnCount() > 3) {
+            String[] headers = rs.getColumnNames();
+            String headName = headers[0];
+            String edgeName = headers[1];
+            String tailName = headers[2];
+            for (int i = 3; i < headers.length; i++) {
+                String attrHeader = headers[i];
+                if (attrHeader.startsWith(headName)) {
+                    headAttributes = addAttribute(headAttributes, headName, i, attrHeader);
+                }
+                else if (attrHeader.startsWith(edgeName)) {
+                    edgeAttributes = addAttribute(edgeAttributes, edgeName, i, attrHeader);
+                }
+                else if (attrHeader.startsWith(tailName)) {
+                    tailAttributes = addAttribute(tailAttributes, tailName, i, attrHeader);
+                }
+                else {
+                    throw new IOException("Column " + (i + 1) + " header '" + headers[i] + "' does not begin with a valid identifier from the first 3 headers: '" + headName + "' or '" + edgeName + "' or '" + tailName + "')");
+                }
+            }
 
-	/**
-	 * Label strings are double quoted, so they cannot contain double quotes or dot file will be invalid
-	 * @param lbl
-	 * @return
-	 */
-	private Object replaceDoubleQuotes(String lbl) {
-		if (lbl.contains("\"")) {
-			lbl = lbl.replace('\"', '\'');
-		}
-		return lbl;
-	}
+        }
+        sb = new StringBuilder("digraph g");
+        sb.append(anchorNodeName);
+        sb.append(" {\n");
+        if (orientation != null && orientation != Orientation.TD){
+            sb.append("   rankdir=");
+            sb.append(orientation.toString());
+            sb.append("\n");
+        }
+        nodes = new ArrayList<String>();
+        sb.append("    label=\"");
+        if (description != null) {
+            sb.append(description);
+        }
+        else {
+            sb.append("Construct ");
+            sb.append(anchorNodeName + 1);
+        }
+        sb.append("\";\n    labelloc=top;\n    labeljust=left;\n");
 
-	private void applyAttributesToNode(Map<Integer, String> attributes, Object[] row, boolean anchored) {
-		boolean anchorFillColorSet = false;
-		boolean fontColorSet = false;
-		if (attributes != null) {
-			Iterator<Integer> itr = attributes.keySet().iterator();
-			while (itr.hasNext()) {
-				Integer key = itr.next();
-				String value = attributes.get(key);		
-				if (row[key.intValue()] != null) {
-					if (value.equals("fontcolor")) {
-						fontColorSet = true;
-					}
-					sb.append(" ");
-					sb.append(value);
-					sb.append("=");
-					if (anchored && value.equals("fillcolor")) {
-						sb.append("\"lightblue:");
-						anchorFillColorSet = true;
-						sb.append(row[key.intValue()]);
-						sb.append("\"");
-					}
-					else {
-						Object rval = row[key.intValue()];
-						if (needsQuotes(rval)) {
-							rval = escapeQuotes(rval.toString());
-							sb.append("\"" + rval + "\"");
-						}
-						else {
-							sb.append(rval);
-						}
-					}
-				}
-			}
-			if (anchored) {
-				if (!anchorFillColorSet) {
-					sb.append(" fillcolor=lightblue");
-					sb.append(" style=filled");
-				}
-				if (!fontColorSet) {
-					sb.append(" fontcolor=navyblue");
-				}
-			}
-		}
-	}
-	
-	private Object escapeQuotes(String str) {
-		if (str.indexOf('\"') > 0) {
-			str = str.replace("\"", "\\\"");
-		}
-		return str;
-	}
+        nothingCount = 0;
+        graphedSubjectMap = null;
+        duplicateObjectMap = null;
 
-	/**
-	 * Method to detect if an attribute value needs to be quoted.
-	 * @param rval
-	 * @return
-	 */
-	private boolean needsQuotes(Object rval) {
-		if (rval instanceof String) {
-			if (rval.toString().indexOf(" ") >= 0) {
-				return true;
-			}
-			String str = (String)rval;
-			for(int i =0; i<str.length(); i++) {
-				char ch = str.charAt(i);
-				if (Character.isWhitespace(ch) || Character.isISOControl(ch)) {
-					return true;
-				}
-				if (ch == '.'){
-					return true;
-				} 
-				if (ch == '-') {
-					return true;
-				}
-			}		
-		}
-		return false;
-	}
+        subjectList = new HashMap<Object, List<Object[]>>();
+        objectList = new HashMap<Object, List<Object[]>>();
+        while (rs.hasNext()) {
+            Object[] row = rs.next();
+            if (row[0] != null) {
+                addRowToMap(subjectList, rs.getShowNamespaces() ? row[0] : rs.extractLocalName(row[0]), row);
+//                subjectList.add(rs.getShowNamespaces() ? row[0] : rs.extractLocalName(row[0]));
+            }
+            if (row[2] != null) {
+                addRowToMap(objectList, rs.getShowNamespaces() ? row[2] : rs.extractLocalName(row[2]), row);
+//                objectList.add(rs.getShowNamespaces() ? row[2] : rs.extractLocalName(row[2]));
+            }
+        }
+        rs.first();    // reset cursor
 
-	private long getSequenceNumber(Map<Integer, String> attributes, Object[] row) {
-		if (attributes != null && attributes.containsValue("sequence_number")) {
-			Iterator<Integer> keyitr = attributes.keySet().iterator();
-			while (keyitr.hasNext()) {
-				Integer key = keyitr.next();
-				String val = attributes.get(key);
-				if (val.equals("sequence_number")) {
-					Object rowval = row[key.intValue()];
-					if (rowval instanceof Long) {
-						return (long) rowval;
-					}
-					return Long.parseLong(rowval.toString());
-				}
-			}
-		}
-		return -1;
-	}
-	
-	private boolean getDuplicateAttribute(Map<Integer, String> attributes, Object[] row) {
-		if(attributes != null && 
-				attributes.containsValue("duplicate")) {
-			Iterator<Integer> keyitr = attributes.keySet().iterator();
-			while (keyitr.hasNext()) {
-				Integer key = keyitr.next();
-				String val = attributes.get(key);
-				if (val.equals("duplicate")) {
-					if(Boolean.parseBoolean((String) row[key.intValue()])) {
-						return true;
-					}
-				}
-			}
-		}
-		return false;
-	}
-	
-	private Map<Integer, String> addAttribute(Map<Integer, String> attrMap, String headName, int columnNumber, String attrHeader) {
-		String attrName = attrHeader.substring(headName.length() + 1);
-		char c = attrHeader.charAt(headName.length());
-		if (c == '_') {
-			if (attrMap == null) {
-				attrMap = new HashMap<Integer, String>();
-			}
-			attrMap.put(columnNumber, attrName);
-		}
-		return attrMap;
-	}
-	
-	private String getTempFolder() {
-		return tempFolder;
-	}
-	
-	private void setTempFolder(String tempFolder) {
-		this.tempFolder = tempFolder;
-	}
-	
-	private String getBaseFileName() {
-		return baseFileName;
-	}
-	
-	private void setBaseFileName(String baseFileName) {
-		this.baseFileName = baseFileName;
-	}
-	
-	private String getAnchorNode() {
-		return anchorNode;
-	}
-	
-	private void setAnchorNode(String anchorNode) {
-		this.anchorNode = anchorNode;
-	}
-	
-	private Orientation getOrientation() {
-		return orientation;
-	}
-	
-	private void setOrientation(Orientation orientation) {
-		this.orientation = orientation;
-	}
-	
-	private String getDescription() {
-		return description;
-	}
-	
-	private void setDescription(String description) {
-		this.description = description;
-	}
-	
-	private String getGraphName() {
-		return graphName;
-	}
-	
-	private void setGraphName(String graphName) {
-		this.graphName = graphName;
-	}
-	
-	@Override
-	public String getGraphFileToOpen() {
-		return graphFileToOpen;
-	}
+        while (rs.hasNext()) {
+            Object[] row = rs.next();
+            String slbl;            // name of start of directed edge
+            Object s;
+            //If this is a single node to be graphed
+            if(row[0] != null && row[1] == null && row[2] == null){
+                //is a single node
+                if (row[0].equals(OWL.Nothing.getURI())) {
+                    s = OWL.Nothing;
+                    slbl = OWL.Nothing.getLocalName() + nothingCount;
+                    nothingCount++;
+                    repeatSubjNode = false;
+                }
+                else {
+                    s = rs.getShowNamespaces() ? row[0] : rs.extractLocalName(row[0]);
+                    if (!nodes.contains(s.toString())) {
+                        nodes.add(s.toString());
+                        slbl = "n" + nodes.size();
+                        repeatSubjNode = false;
+                    }
+                    else {
+                        slbl = "n" + (nodes.indexOf(s.toString()) + 1);
+                        repeatSubjNode = true;
+                    }
+                }
+                sb.append("     ");
+                if (!repeatSubjNode) {
+                    sb.append(slbl);
+                    if(s.equals(OWL.Nothing)) {
+                        sb.append("[shape=point label=\"");
+                    }
+                    else {
+                        sb.append("[shape=box label=\"");
+                    }
+                    sb.append(s.toString());
+                    sb.append("\"");
+                    boolean anchored = false;
+                    if (anchorNodeLabel != null && s.toString().equals(anchorNodeLabel)) {
+                        anchored = true;
+                    }
+                    applyAttributesToNode(headAttributes, row, anchored);
+                    sb.append("];\n");
+                }
 
-	@Override
-	public String getGraphFilenameExtension() {
-		return ".svg";
-	}
+                continue;
+
+            }else if (row[0] == null && row[1] == null && row[2] == null) {
+                continue;
+            }
+
+            s = rs.getShowNamespaces() ? row[0] : rs.extractLocalName(row[0]);
+            String edgeLbl = rs.getShowNamespaces() ? row[1].toString() : rs.extractLocalName(row[1]);
+            Object o = rs.getShowNamespaces() ? row[2] : rs.extractLocalName(row[2]);
+
+            createGraphTriple(s, edgeLbl, o, headAttributes, edgeAttributes, tailAttributes, row, anchorNodeLabel, null);
+        }
+        if (duplicateObjectMap != null) {
+            Iterator<String> objitr = duplicateObjectMap.keySet().iterator();
+            while (objitr.hasNext()) {
+                String key = objitr.next();
+                String objnm = duplicateObjectMap.get(key);
+                if (graphedSubjectMap != null && graphedSubjectMap.containsValue(objnm) && !graphedSubjectMap.containsKey(key)) {
+                    // we need to fill out missing branches
+                    rs.first();
+                    while (rs.hasNext()) {
+                        Object[] row = rs.next();
+                        if (row[0].equals(objnm)) {
+                            Object s = rs.getShowNamespaces() ? row[0] : rs.extractLocalName(row[0]);
+                            String edgeLbl = rs.getShowNamespaces() ? row[1].toString() : rs.extractLocalName(row[1]);
+                            Object o = rs.getShowNamespaces() ? row[2] : rs.extractLocalName(row[2]);
+                            createGraphTriple(s, edgeLbl, o, headAttributes, edgeAttributes, tailAttributes, row, anchorNodeLabel, key);
+                        }
+                    }
+                }
+            }
+        }
+        sb.append("}\n");
+        File dotFile = new java.io.File(tmpdir.getAbsolutePath() + File.separator +
+                ((bfn != null ? bfn : "") + ".dot"));
+        new SadlUtils().stringToFile(dotFile, sb.toString(), false);
+        return dotFile;
+    }
+
+    private void addRowToMap(HashMap<Object, List<Object[]>> list, Object key, Object[] row) {
+        if (list.containsKey(key)) {
+            list.get(key).add(row);
+        }
+        else {
+            List<Object[]> valList = new ArrayList<Object[]>();
+            valList.add(row);
+            list.put(key, valList);
+        }
+    }
+
+    private void createGraphTriple(Object s, String edgeLbl, Object o, Map<Integer, String> headAttributes, Map<Integer, String> edgeAttributes, Map<Integer,
+            String> tailAttributes, Object[] row, String anchorNodeLabel, String subjectNode) {
+        String slbl = subjectNode;
+        String olbl;
+        if (slbl == null) {
+            if (row[0].equals(OWL.Nothing.getURI())) {
+                s = OWL.Nothing;
+                slbl = OWL.Nothing.getLocalName() + nothingCount;
+                nothingCount++;
+                repeatSubjNode = false;
+            }
+            else {
+                //check if this node should be duplicated: Used in graphing context AATIM-1389
+                boolean duplicateNode = getDuplicateAttribute(headAttributes, row);
+                long headSequenceNum = getSequenceNumber(headAttributes, row);
+                if (duplicateNode || headSequenceNum > 0) {
+                    //don't check to see if this node is in nodes
+                    nodes.add(s.toString());
+                    if (headSequenceNum > 0) {
+                        slbl = "n" + headSequenceNum;
+                    }
+                    else {
+                        slbl = "n" + nodes.size();
+                    }
+                    repeatSubjNode = false;
+                }else if (!nodes.contains(s.toString())) {
+                    nodes.add(s.toString());
+                    slbl = "n" + nodes.size();
+                    repeatSubjNode = false;
+                }
+                else {
+                    slbl = "n" + (nodes.indexOf(s.toString()) + 1);
+                    repeatSubjNode = true;
+                }
+                if (graphedSubjectMap == null) {
+                    graphedSubjectMap = new HashMap<String,String>();
+                }
+                graphedSubjectMap.put(slbl, s.toString());
+            }
+        }
+        else {
+            repeatSubjNode = true;
+        }
+        if (row[2] != null && row[2].equals(OWL.Nothing.getURI())) {
+            o = OWL.Nothing;
+            olbl = OWL.Nothing.getLocalName() + nothingCount;
+            nothingCount++;
+            repeatObjNode = false;
+        }
+        else {
+            //check if this node should be duplicated: Used in graphing context AATIM-1389
+            boolean duplicateNode = getDuplicateAttribute(tailAttributes, row);
+            long tailSequenceNum = getSequenceNumber(tailAttributes, row);
+            if(duplicateNode || tailSequenceNum > 0){
+                //don't check to see if this node is in nodes
+                nodes.add(o.toString());
+                if (tailSequenceNum > 0) {
+                    olbl = "n" + tailSequenceNum;
+                }
+                else {
+                    olbl = "n" + nodes.size();
+                }
+                repeatObjNode = false;
+                if (subjectNode == null && repeatSubjNode) {
+                    // now we want to expand out any children that this duplicate should have so it continues what's in the data...
+                    if (duplicateObjectMap == null) {
+                        duplicateObjectMap = new HashMap<String,String>();
+                    }
+                    duplicateObjectMap.put(olbl, o.toString());
+                }
+            }else if (!nodes.contains(o.toString())) {
+                nodes.add(o.toString());
+                olbl = "n" + nodes.size();
+                repeatObjNode = false;
+            }
+            else {
+                olbl = "n" + (nodes.indexOf(o.toString()) + 1);
+                repeatObjNode = true;
+            }
+        }
+        sb.append("     ");
+        if (!repeatSubjNode) {
+            sb.append(slbl);
+            if(s.equals(OWL.Nothing)) {
+                sb.append("[shape=point label=\"");
+            }
+            else {
+                sb.append("[shape=box label=\"");
+            }
+            sb.append(replaceDoubleQuotes(s.toString()));
+            sb.append("\"");
+            boolean anchored = false;
+            if (anchorNodeLabel != null && s.toString().equals(anchorNodeLabel)) {
+                anchored = true;
+            }
+            applyAttributesToNode(headAttributes, row, anchored);
+            if (objectList.containsKey(s)) {
+                List<Object[]> valList = objectList.get(s);
+                for (int i = 0; i < valList.size(); i++) {
+                    applyAttributesToNode(tailAttributes, valList.get(i), anchored);
+                }
+            }
+            sb.append("];\n");
+        }
+        if (!repeatObjNode) {
+            sb.append("     ");
+            sb.append(olbl);
+            if (o.equals(OWL.Nothing)) {
+                sb.append("[shape=point label=\"");
+            }
+            else {
+                sb.append("[shape=box label=\"");
+            }
+            sb.append(replaceDoubleQuotes(o.toString()));
+            sb.append("\"");
+            boolean anchored = false;
+            if (anchorNodeLabel != null && o.toString().equals(anchorNodeLabel)) {
+                anchored = true;
+            }
+            applyAttributesToNode(tailAttributes, row, anchored);
+            if (subjectList.containsKey(o)) {
+                List<Object[]> valList = subjectList.get(o);
+                for (int i = 0; i < valList.size(); i++) {
+                    applyAttributesToNode(headAttributes, valList.get(i), anchored);
+                }
+            }
+            sb.append("];\n");
+        }
+        sb.append("     ");
+        sb.append(slbl);
+        sb.append("->");
+        sb.append(olbl);
+        sb.append("[");
+        boolean anchored = false;
+        if (row[1] != null && row[1].toString().length() > 0) {
+            if (anchorNodeLabel != null && edgeLbl.equals(anchorNodeLabel)) {
+                anchored = true;
+            }
+            sb.append("label=\"");
+            sb.append(replaceDoubleQuotes(edgeLbl));
+            sb.append("\"");
+            // color the "anchor" edge
+            if (anchored) {
+                sb.append(" style=bold");
+            }
+        }
+        if (edgeAttributes != null) {
+            Iterator<Integer> itr = edgeAttributes.keySet().iterator();
+            while (itr.hasNext()) {
+                Integer key = itr.next();
+                String value = edgeAttributes.get(key);
+                if (anchored && value.equals("style")) {
+                    continue; // already set
+                }
+                if (row[key.intValue()] != null) {
+                    sb.append(" ");
+                    sb.append(value);
+                    sb.append("=");
+                    sb.append(row[key.intValue()]);
+                }
+            }
+        }
+        sb.append("];\n");
+    }
+
+    /**
+     * Label strings are double quoted, so they cannot contain double quotes or dot file will be invalid
+     * @param lbl
+     * @return
+     */
+    private Object replaceDoubleQuotes(String lbl) {
+        if (lbl.contains("\"")) {
+            lbl = lbl.replace('\"', '\'');
+        }
+        return lbl;
+    }
+
+    private void applyAttributesToNode(Map<Integer, String> attributes, Object[] row, boolean anchored) {
+        boolean anchorFillColorSet = false;
+        boolean fontColorSet = false;
+        if (attributes != null) {
+            Iterator<Integer> itr = attributes.keySet().iterator();
+            while (itr.hasNext()) {
+                Integer key = itr.next();
+                String value = attributes.get(key);
+                if (row[key.intValue()] != null) {
+                    if (value.equals("fontcolor")) {
+                        fontColorSet = true;
+                    }
+                    sb.append(" ");
+                    sb.append(value);
+                    sb.append("=");
+                    if (anchored && value.equals("fillcolor")) {
+                        sb.append("\"lightblue:");
+                        anchorFillColorSet = true;
+                        sb.append(row[key.intValue()]);
+                        sb.append("\"");
+                    }
+                    else {
+                        Object rval = row[key.intValue()];
+                        if (needsQuotes(rval)) {
+                            rval = escapeQuotes(rval.toString());
+                            sb.append("\"" + rval + "\"");
+                        }
+                        else {
+                            sb.append(rval);
+                        }
+                    }
+                }
+            }
+            if (anchored) {
+                if (!anchorFillColorSet) {
+                    sb.append(" fillcolor=lightblue");
+                    sb.append(" style=filled");
+                }
+                if (!fontColorSet) {
+                    sb.append(" fontcolor=navyblue");
+                }
+            }
+        }
+    }
+
+    private Object escapeQuotes(String str) {
+        if (str.indexOf('\"') > 0) {
+            str = str.replace("\"", "\\\"");
+        }
+        return str;
+    }
+
+    /**
+     * Method to detect if an attribute value needs to be quoted.
+     * @param rval
+     * @return
+     */
+    private boolean needsQuotes(Object rval) {
+        if (rval instanceof String) {
+            if (rval.toString().indexOf(" ") >= 0) {
+                return true;
+            }
+            String str = (String)rval;
+            for(int i =0; i<str.length(); i++) {
+                char ch = str.charAt(i);
+                if (Character.isWhitespace(ch) || Character.isISOControl(ch)) {
+                    return true;
+                }
+                if (ch == '.'){
+                    return true;
+                }
+                if (ch == '-') {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private long getSequenceNumber(Map<Integer, String> attributes, Object[] row) {
+        if (attributes != null && attributes.containsValue("sequence_number")) {
+            Iterator<Integer> keyitr = attributes.keySet().iterator();
+            while (keyitr.hasNext()) {
+                Integer key = keyitr.next();
+                String val = attributes.get(key);
+                if (val.equals("sequence_number")) {
+                    Object rowval = row[key.intValue()];
+                    if (rowval instanceof Long) {
+                        return (long) rowval;
+                    }
+                    return Long.parseLong(rowval.toString());
+                }
+            }
+        }
+        return -1;
+    }
+
+    private boolean getDuplicateAttribute(Map<Integer, String> attributes, Object[] row) {
+        if(attributes != null &&
+                attributes.containsValue("duplicate")) {
+            Iterator<Integer> keyitr = attributes.keySet().iterator();
+            while (keyitr.hasNext()) {
+                Integer key = keyitr.next();
+                String val = attributes.get(key);
+                if (val.equals("duplicate")) {
+                    if(Boolean.parseBoolean((String) row[key.intValue()])) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    private Map<Integer, String> addAttribute(Map<Integer, String> attrMap, String headName, int columnNumber, String attrHeader) {
+        String attrName = attrHeader.substring(headName.length() + 1);
+        char c = attrHeader.charAt(headName.length());
+        if (c == '_') {
+            if (attrMap == null) {
+                attrMap = new HashMap<Integer, String>();
+            }
+            attrMap.put(columnNumber, attrName);
+        }
+        return attrMap;
+    }
+
+    private String getTempFolder() {
+        return tempFolder;
+    }
+
+    private void setTempFolder(String tempFolder) {
+        this.tempFolder = tempFolder;
+    }
+
+    private String getBaseFileName() {
+        return baseFileName;
+    }
+
+    private void setBaseFileName(String baseFileName) {
+        this.baseFileName = baseFileName;
+    }
+
+    private String getAnchorNode() {
+        return anchorNode;
+    }
+
+    private void setAnchorNode(String anchorNode) {
+        this.anchorNode = anchorNode;
+    }
+
+    private Orientation getOrientation() {
+        return orientation;
+    }
+
+    private void setOrientation(Orientation orientation) {
+        this.orientation = orientation;
+    }
+
+    private String getDescription() {
+        return description;
+    }
+
+    private void setDescription(String description) {
+        this.description = description;
+    }
+
+    private String getGraphName() {
+        return graphName;
+    }
+
+    private void setGraphName(String graphName) {
+        this.graphName = graphName;
+    }
+
+    @Override
+    public String getGraphFileToOpen() {
+        return graphFileToOpen;
+    }
+
+    @Override
+    public String getGraphFilenameExtension() {
+        return ".svg";
+    }
 }

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.reasoner-impl/src/main/java/com/ge/research/sadl/model/visualizer/GraphVizVisualizer.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.reasoner-impl/src/main/java/com/ge/research/sadl/model/visualizer/GraphVizVisualizer.java
@@ -17,654 +17,654 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class GraphVizVisualizer implements IGraphVisualizer {
+	
+	private final Logger logger = LoggerFactory.getLogger(GraphVizVisualizer.class);
+	private String tempFolder = null;
+	private String baseFileName = null;
+	private String graphName = null;
+	private String anchorNode = null;
+	private Orientation orientation = null;
+	private String description = null;
+	
+	private String graphFileToOpen = null;
+	private int nothingCount;
+	private HashMap<String,String> graphedSubjectMap;
+	private HashMap<String,String> duplicateObjectMap;
+	private StringBuilder sb;
+	private boolean repeatObjNode;
+	private boolean repeatSubjNode;
+	private List<String> nodes;
+	private HashMap<Object, List<Object[]>> subjectList;
+	private HashMap<Object, List<Object[]>> objectList;
 
-    private final Logger logger = LoggerFactory.getLogger(GraphVizVisualizer.class);
-    private String tempFolder = null;
-    private String baseFileName = null;
-    private String graphName = null;
-    private String anchorNode = null;
-    private Orientation orientation = null;
-    private String description = null;
+	@Override
+	public void initialize(String tempDir, String bfn, String graphName, String anchorNode, Orientation orientation, String description) {
+		setTempFolder(tempDir);
+		setBaseFileName(bfn);
+		setGraphName(graphName);
+		setAnchorNode(anchorNode);
+		setOrientation(orientation);
+		setDescription(description);
+	}
+	
+	@Override
+	public List<String> graphCsvData(String csvFilepath) throws IOException {
+		throw new IOException("Method graphCsvData(String filepath) not yet implemented");
+	}
 
-    private String graphFileToOpen = null;
-    private int nothingCount;
-    private HashMap<String,String> graphedSubjectMap;
-    private HashMap<String,String> duplicateObjectMap;
-    private StringBuilder sb;
-    private boolean repeatObjNode;
-    private boolean repeatSubjNode;
-    private List<String> nodes;
-    private HashMap<Object, List<Object[]>> subjectList;
-    private HashMap<Object, List<Object[]>> objectList;
+	@Override
+	public List<String> graphCsvData(DataSource ds) throws IOException {
+		throw new IOException("Method graphCsvData(DataSource ds) not yet implemented");
+	}
 
-    @Override
-    public void initialize(String tempDir, String bfn, String graphName, String anchorNode, Orientation orientation, String description) {
-        setTempFolder(tempDir);
-        setBaseFileName(bfn);
-        setGraphName(graphName);
-        setAnchorNode(anchorNode);
-        setOrientation(orientation);
-        setDescription(description);
-    }
+	@Override
+	public List<String> graphResultSetData(ResultSet rs) throws IOException {
+		File dotFile = constructResultSetToDotFile(rs, new File(getTempFolder()), getBaseFileName(), getGraphName(), getAnchorNode(), getDescription(), getOrientation());
+		createGraphVizGraph(dotFile.getCanonicalPath());
+		return null;
+	}
 
-    @Override
-    public List<String> graphCsvData(String csvFilepath) throws IOException {
-        throw new IOException("Method graphCsvData(String filepath) not yet implemented");
-    }
+	public void createGraphVizGraph(String dotfilepath) throws IOException {
+		String exec = System.getenv("GraphVizPath");
+		if (exec == null) {
+			Map<String, String> map = System.getenv();
+			Iterator<String> mitr = map.keySet().iterator();
+			while (mitr.hasNext()) {
+				String key = mitr.next();
+				String val = map.get(key);
+				logger.debug(key + " -> " + val);
+			}
+		}
+		if (exec == null || exec.length() == 0) {
+			throw new IOException("Unable to find GraphVizPath. Please set GraphVizPath environment variable to the GraphViz bin folder path.");
+		}
+    	String dotexec = null;
+    	if (!exec.endsWith("dotty") && !exec.endsWith("dotty.exe")) {
+    		dotexec = exec + File.separator + "dot";
+    		exec = exec + File.separator + "dotty";
+    	}
+		if (dotexec != null) {
+			// dot -Tps filename.dot -o outfile.ps
+			String svgfilepath = dotfilepath;
+			if (dotfilepath.endsWith(".dot")) {
+				svgfilepath = dotfilepath.substring(0, dotfilepath.length() - 4);
+			}
+			String svgfn = svgfilepath + getGraphFilenameExtension();
+			File f = new File(svgfn);
+			if (f.exists()) {
+				boolean status = f.delete();
+				if (!status) {
+					throw new IOException("Unable to delete existing file '" + svgfn + "'.");
+				}
+			}
+			ProcessBuilder bppng = new ProcessBuilder(dotexec, "-Tsvg", dotfilepath,"-o", svgfn);
+			try {
+				bppng.start();
+				Thread.sleep(100);
+				graphFileToOpen = svgfn;
+			} catch (IOException e) {
+				throw new IOException("Unable to run GraphViz dot to generate PNG file; is GraphViz path set properly? (" + e.getMessage() + ")");
+			} catch (InterruptedException e) {
+				logger.error("Ignoring " + e, e);
+			}
+			int cntr = 0;
+			File fto = new File(graphFileToOpen);
+			while (cntr++ < 50 && !fto.exists()) {
+				try {
+					Thread.sleep(200);
+				} catch (InterruptedException e) {
+					logger.error("Ignoring " + e, e);
+				}
+			}
+			if (!fto.exists()) {
+				ProcessBuilder pb = new ProcessBuilder(exec, dotfilepath);
+				try {
+					pb.start();
+				} catch (IOException e2) {
+					throw new IOException("Unable to run GraphViz dotty; is GraphViz installed and on path? (" + e2.getMessage() + ")");
+				}
+			}
+			else {
+				String dontdelete = System.getenv("GraphVizKeepDot");
+				if (dontdelete == null || !dontdelete.equalsIgnoreCase("true")) {
+					// delete the .dot file
+					File dotfile = new File(dotfilepath);
+					if (dotfile.exists()) {
+						dotfile.delete();
+					}
+				}
+			}
+		}
+	}
 
-    @Override
-    public List<String> graphCsvData(DataSource ds) throws IOException {
-        throw new IOException("Method graphCsvData(DataSource ds) not yet implemented");
-    }
+	/**
+	 * Method to create a GraphViz .dot file from a construct ResultSet
+	 * @param rs
+	 * @param tmpdir
+	 * @param bfn -- base file name to use for output file
+	 * @param anchorNodeName -- 
+	 * @param anchorNodeLabel -- the node which is the anchor (colored differently)
+	 * @param description
+	 * @param orientation
+	 * @return
+	 * @throws IOException
+	 */
+	public File constructResultSetToDotFile(ResultSet rs, File tmpdir, String bfn, String anchorNodeName, String anchorNodeLabel, String description, Orientation orientation) throws IOException {
+		Map<Integer,String> headAttributes = null;
+		Map<Integer,String> edgeAttributes = null;
+		Map<Integer,String> tailAttributes = null;
+		if (rs.getColumnCount() > 3) {
+			String[] headers = rs.getColumnNames();
+			String headName = headers[0];
+			String edgeName = headers[1];
+			String tailName = headers[2];
+			for (int i = 3; i < headers.length; i++) {
+				String attrHeader = headers[i];
+				if (attrHeader.startsWith(headName)) {
+					headAttributes = addAttribute(headAttributes, headName, i, attrHeader);
+				}
+				else if (attrHeader.startsWith(edgeName)) {
+					edgeAttributes = addAttribute(edgeAttributes, edgeName, i, attrHeader);
+				}
+				else if (attrHeader.startsWith(tailName)) {
+					tailAttributes = addAttribute(tailAttributes, tailName, i, attrHeader);
+				}
+				else {
+					throw new IOException("Column " + (i + 1) + " header '" + headers[i] + "' does not begin with a valid identifier from the first 3 headers: '" + headName + "' or '" + edgeName + "' or '" + tailName + "')");
+				}
+			}
+			
+		}
+		sb = new StringBuilder("digraph g");
+		sb.append(anchorNodeName);
+		sb.append(" {\n");
+		if (orientation != null && orientation != Orientation.TD){
+			sb.append("   rankdir=");
+			sb.append(orientation.toString());
+			sb.append("\n");
+		}
+		nodes = new ArrayList<String>();
+		sb.append("    label=\"");
+		if (description != null) {
+			sb.append(description);
+		}
+		else {
+			sb.append("Construct ");
+			sb.append(anchorNodeName + 1);
+		}
+		sb.append("\";\n    labelloc=top;\n    labeljust=left;\n");
+		
+		nothingCount = 0;
+		graphedSubjectMap = null;
+		duplicateObjectMap = null;
+		
+		subjectList = new HashMap<Object, List<Object[]>>();
+		objectList = new HashMap<Object, List<Object[]>>();
+		while (rs.hasNext()) {
+			Object[] row = rs.next();
+			if (row[0] != null) {
+				addRowToMap(subjectList, rs.getShowNamespaces() ? row[0] : rs.extractLocalName(row[0]), row);
+//				subjectList.add(rs.getShowNamespaces() ? row[0] : rs.extractLocalName(row[0]));
+			}
+			if (row[2] != null) {
+				addRowToMap(objectList, rs.getShowNamespaces() ? row[2] : rs.extractLocalName(row[2]), row);
+//				objectList.add(rs.getShowNamespaces() ? row[2] : rs.extractLocalName(row[2]));
+			}
+		}
+		rs.first();	// reset cursor
+		
+		while (rs.hasNext()) {
+			Object[] row = rs.next();
+			String slbl;			// name of start of directed edge
+			Object s;
+			//If this is a single node to be graphed
+			if(row[0] != null && row[1] == null && row[2] == null){
+				//is a single node
+				if (row[0].equals(OWL.Nothing.getURI())) {
+					s = OWL.Nothing;
+					slbl = OWL.Nothing.getLocalName() + nothingCount;
+					nothingCount++;
+					repeatSubjNode = false;
+				}
+				else {
+					s = rs.getShowNamespaces() ? row[0] : rs.extractLocalName(row[0]);
+					if (!nodes.contains(s.toString())) {
+						nodes.add(s.toString());
+						slbl = "n" + nodes.size();
+						repeatSubjNode = false;
+					}
+					else {
+						slbl = "n" + (nodes.indexOf(s.toString()) + 1);
+						repeatSubjNode = true;
+					}
+				}
+				sb.append("     ");
+				if (!repeatSubjNode) {
+					sb.append(slbl);
+					if(s.equals(OWL.Nothing)) {
+						sb.append("[shape=point label=\"");
+					}
+					else {
+						sb.append("[shape=box label=\"");
+					}
+					sb.append(s.toString());
+					sb.append("\"");
+					boolean anchored = false;
+					if (anchorNodeLabel != null && s.toString().equals(anchorNodeLabel)) {
+						anchored = true;
+					}
+					applyAttributesToNode(headAttributes, row, anchored);
+					sb.append("];\n");
+				}
 
-    @Override
-    public List<String> graphResultSetData(ResultSet rs) throws IOException {
-        File dotFile = constructResultSetToDotFile(rs, new File(getTempFolder()), getBaseFileName(), getGraphName(), getAnchorNode(), getDescription(), getOrientation());
-        createGraphVizGraph(dotFile.getCanonicalPath());
-        return null;
-    }
+				continue;
+				
+			}else if (row[0] == null && row[1] == null && row[2] == null) {
+				continue;
+			}
+			
+			s = rs.getShowNamespaces() ? row[0] : rs.extractLocalName(row[0]);
+			String edgeLbl = rs.getShowNamespaces() ? row[1].toString() : rs.extractLocalName(row[1]);
+			Object o = rs.getShowNamespaces() ? row[2] : rs.extractLocalName(row[2]);
 
-    public void createGraphVizGraph(String dotfilepath) throws IOException {
-        String exec = System.getenv("GraphVizPath");
-        if (exec == null) {
-            Map<String, String> map = System.getenv();
-            Iterator<String> mitr = map.keySet().iterator();
-            while (mitr.hasNext()) {
-                String key = mitr.next();
-                String val = map.get(key);
-                logger.debug(key + " -> " + val);
-            }
-        }
-        if (exec == null || exec.length() == 0) {
-            throw new IOException("Unable to find GraphVizPath. Please set GraphVizPath environment variable to the GraphViz bin folder path.");
-        }
-        String dotexec = null;
-        if (!exec.endsWith("dotty") && !exec.endsWith("dotty.exe")) {
-            dotexec = exec + File.separator + "dot";
-            exec = exec + File.separator + "dotty";
-        }
-        if (dotexec != null) {
-            // dot -Tps filename.dot -o outfile.ps
-            String svgfilepath = dotfilepath;
-            if (dotfilepath.endsWith(".dot")) {
-                svgfilepath = dotfilepath.substring(0, dotfilepath.length() - 4);
-            }
-            String svgfn = svgfilepath + getGraphFilenameExtension();
-            File f = new File(svgfn);
-            if (f.exists()) {
-                boolean status = f.delete();
-                if (!status) {
-                    throw new IOException("Unable to delete existing file '" + svgfn + "'.");
-                }
-            }
-            ProcessBuilder bppng = new ProcessBuilder(dotexec, "-Tsvg", dotfilepath,"-o", svgfn);
-            try {
-                bppng.start();
-                Thread.sleep(100);
-                graphFileToOpen = svgfn;
-            } catch (IOException e) {
-                throw new IOException("Unable to run GraphViz dot to generate PNG file; is GraphViz path set properly? (" + e.getMessage() + ")");
-            } catch (InterruptedException e) {
-                logger.error("Ignoring " + e, e);
-            }
-            int cntr = 0;
-            File fto = new File(graphFileToOpen);
-            while (cntr++ < 50 && !fto.exists()) {
-                try {
-                    Thread.sleep(200);
-                } catch (InterruptedException e) {
-                    logger.error("Ignoring " + e, e);
-                }
-            }
-            if (!fto.exists()) {
-                ProcessBuilder pb = new ProcessBuilder(exec, dotfilepath);
-                try {
-                    pb.start();
-                } catch (IOException e2) {
-                    throw new IOException("Unable to run GraphViz dotty; is GraphViz installed and on path? (" + e2.getMessage() + ")");
-                }
-            }
-            else {
-                String dontdelete = System.getenv("GraphVizKeepDot");
-                if (dontdelete == null || !dontdelete.equalsIgnoreCase("true")) {
-                    // delete the .dot file
-                    File dotfile = new File(dotfilepath);
-                    if (dotfile.exists()) {
-                        dotfile.delete();
-                    }
-                }
-            }
-        }
-    }
+			createGraphTriple(s, edgeLbl, o, headAttributes, edgeAttributes, tailAttributes, row, anchorNodeLabel, null);
+		}
+		if (duplicateObjectMap != null) {
+			Iterator<String> objitr = duplicateObjectMap.keySet().iterator();
+			while (objitr.hasNext()) {
+				String key = objitr.next();
+				String objnm = duplicateObjectMap.get(key);
+				if (graphedSubjectMap != null && graphedSubjectMap.containsValue(objnm) && !graphedSubjectMap.containsKey(key)) {
+					// we need to fill out missing branches
+					rs.first();
+					while (rs.hasNext()) {
+						Object[] row = rs.next();
+						if (row[0].equals(objnm)) {
+							Object s = rs.getShowNamespaces() ? row[0] : rs.extractLocalName(row[0]);
+							String edgeLbl = rs.getShowNamespaces() ? row[1].toString() : rs.extractLocalName(row[1]);
+							Object o = rs.getShowNamespaces() ? row[2] : rs.extractLocalName(row[2]);
+							createGraphTriple(s, edgeLbl, o, headAttributes, edgeAttributes, tailAttributes, row, anchorNodeLabel, key);
+						}
+					}
+				}
+			}
+		}
+		sb.append("}\n");
+		File dotFile = new java.io.File(tmpdir.getAbsolutePath() + File.separator + 
+				((bfn != null ? bfn : "") + ".dot"));
+		new SadlUtils().stringToFile(dotFile, sb.toString(), false);
+		return dotFile;
+	}
+	
+	private void addRowToMap(HashMap<Object, List<Object[]>> list, Object key, Object[] row) {
+		if (list.containsKey(key)) {
+			list.get(key).add(row);
+		}
+		else {
+			List<Object[]> valList = new ArrayList<Object[]>();
+			valList.add(row);
+			list.put(key, valList);
+		}	
+	}
 
-    /**
-     * Method to create a GraphViz .dot file from a construct ResultSet
-     * @param rs
-     * @param tmpdir
-     * @param bfn -- base file name to use for output file
-     * @param anchorNodeName --
-     * @param anchorNodeLabel -- the node which is the anchor (colored differently)
-     * @param description
-     * @param orientation
-     * @return
-     * @throws IOException
-     */
-    public File constructResultSetToDotFile(ResultSet rs, File tmpdir, String bfn, String anchorNodeName, String anchorNodeLabel, String description, Orientation orientation) throws IOException {
-        Map<Integer,String> headAttributes = null;
-        Map<Integer,String> edgeAttributes = null;
-        Map<Integer,String> tailAttributes = null;
-        if (rs.getColumnCount() > 3) {
-            String[] headers = rs.getColumnNames();
-            String headName = headers[0];
-            String edgeName = headers[1];
-            String tailName = headers[2];
-            for (int i = 3; i < headers.length; i++) {
-                String attrHeader = headers[i];
-                if (attrHeader.startsWith(headName)) {
-                    headAttributes = addAttribute(headAttributes, headName, i, attrHeader);
-                }
-                else if (attrHeader.startsWith(edgeName)) {
-                    edgeAttributes = addAttribute(edgeAttributes, edgeName, i, attrHeader);
-                }
-                else if (attrHeader.startsWith(tailName)) {
-                    tailAttributes = addAttribute(tailAttributes, tailName, i, attrHeader);
-                }
-                else {
-                    throw new IOException("Column " + (i + 1) + " header '" + headers[i] + "' does not begin with a valid identifier from the first 3 headers: '" + headName + "' or '" + edgeName + "' or '" + tailName + "')");
-                }
-            }
+	private void createGraphTriple(Object s, String edgeLbl, Object o, Map<Integer, String> headAttributes, Map<Integer, String> edgeAttributes, Map<Integer, 
+			String> tailAttributes, Object[] row, String anchorNodeLabel, String subjectNode) {
+		String slbl = subjectNode;
+		String olbl;
+		if (slbl == null) {
+			if (row[0].equals(OWL.Nothing.getURI())) {
+				s = OWL.Nothing;
+				slbl = OWL.Nothing.getLocalName() + nothingCount;
+				nothingCount++;
+				repeatSubjNode = false;
+			}
+			else {
+				//check if this node should be duplicated: Used in graphing context AATIM-1389
+				boolean duplicateNode = getDuplicateAttribute(headAttributes, row);
+				long headSequenceNum = getSequenceNumber(headAttributes, row);
+				if (duplicateNode || headSequenceNum > 0) {
+					//don't check to see if this node is in nodes
+					nodes.add(s.toString());
+					if (headSequenceNum > 0) {
+						slbl = "n" + headSequenceNum;
+					}
+					else {
+						slbl = "n" + nodes.size();
+					}
+					repeatSubjNode = false;
+				}else if (!nodes.contains(s.toString())) {
+					nodes.add(s.toString());
+					slbl = "n" + nodes.size();
+					repeatSubjNode = false;
+				}
+				else {
+					slbl = "n" + (nodes.indexOf(s.toString()) + 1);
+					repeatSubjNode = true;
+				}
+				if (graphedSubjectMap == null) {
+					graphedSubjectMap = new HashMap<String,String>();
+				}
+				graphedSubjectMap.put(slbl, s.toString());
+			}
+		}
+		else {
+			repeatSubjNode = true;
+		}
+		if (row[2] != null && row[2].equals(OWL.Nothing.getURI())) {
+			o = OWL.Nothing;
+			olbl = OWL.Nothing.getLocalName() + nothingCount;
+			nothingCount++;
+			repeatObjNode = false;
+		}
+		else {
+			//check if this node should be duplicated: Used in graphing context AATIM-1389
+			boolean duplicateNode = getDuplicateAttribute(tailAttributes, row);
+			long tailSequenceNum = getSequenceNumber(tailAttributes, row);
+			if(duplicateNode || tailSequenceNum > 0){
+				//don't check to see if this node is in nodes
+				nodes.add(o.toString());
+				if (tailSequenceNum > 0) {
+					olbl = "n" + tailSequenceNum;
+				}
+				else {
+					olbl = "n" + nodes.size();
+				}
+				repeatObjNode = false;
+				if (subjectNode == null && repeatSubjNode) {
+					// now we want to expand out any children that this duplicate should have so it continues what's in the data...
+					if (duplicateObjectMap == null) {
+						duplicateObjectMap = new HashMap<String,String>();
+					}
+					duplicateObjectMap.put(olbl, o.toString());
+				}
+			}else if (!nodes.contains(o.toString())) {
+				nodes.add(o.toString());
+				olbl = "n" + nodes.size();
+				repeatObjNode = false;
+			}
+			else {
+				olbl = "n" + (nodes.indexOf(o.toString()) + 1);
+				repeatObjNode = true;
+			}
+		}
+		sb.append("     ");
+		if (!repeatSubjNode) {
+			sb.append(slbl);
+			if(s.equals(OWL.Nothing)) {
+				sb.append("[shape=point label=\"");
+			}
+			else {
+				sb.append("[shape=box label=\"");
+			}
+			sb.append(replaceDoubleQuotes(s.toString()));
+			sb.append("\"");
+			boolean anchored = false;
+			if (anchorNodeLabel != null && s.toString().equals(anchorNodeLabel)) {
+				anchored = true;
+			}
+			applyAttributesToNode(headAttributes, row, anchored);
+			if (objectList.containsKey(s)) {
+				List<Object[]> valList = objectList.get(s);
+				for (int i = 0; i < valList.size(); i++) {
+					applyAttributesToNode(tailAttributes, valList.get(i), anchored);
+				}
+			}
+			sb.append("];\n");
+		}
+		if (!repeatObjNode) {
+			sb.append("     ");
+			sb.append(olbl);
+			if (o.equals(OWL.Nothing)) {
+				sb.append("[shape=point label=\"");
+			}
+			else {
+				sb.append("[shape=box label=\"");
+			}
+			sb.append(replaceDoubleQuotes(o.toString()));
+			sb.append("\"");
+			boolean anchored = false;
+			if (anchorNodeLabel != null && o.toString().equals(anchorNodeLabel)) {
+				anchored = true;
+			}
+			applyAttributesToNode(tailAttributes, row, anchored);
+			if (subjectList.containsKey(o)) {
+				List<Object[]> valList = subjectList.get(o);
+				for (int i = 0; i < valList.size(); i++) {
+					applyAttributesToNode(headAttributes, valList.get(i), anchored);
+				}
+			}
+			sb.append("];\n");
+		}
+		sb.append("     ");
+		sb.append(slbl);
+		sb.append("->");
+		sb.append(olbl);
+		sb.append("[");
+		boolean anchored = false;
+		if (row[1] != null && row[1].toString().length() > 0) {
+			if (anchorNodeLabel != null && edgeLbl.equals(anchorNodeLabel)) {
+				anchored = true;
+			}
+			sb.append("label=\"");
+			sb.append(replaceDoubleQuotes(edgeLbl));
+			sb.append("\"");
+			// color the "anchor" edge
+			if (anchored) {
+				sb.append(" style=bold");
+			}
+		}
+		if (edgeAttributes != null) {
+			Iterator<Integer> itr = edgeAttributes.keySet().iterator();
+			while (itr.hasNext()) {
+				Integer key = itr.next();
+				String value = edgeAttributes.get(key);
+				if (anchored && value.equals("style")) {
+					continue; // already set
+				}
+				if (row[key.intValue()] != null) {
+					sb.append(" ");
+					sb.append(value);
+					sb.append("=");
+					sb.append(row[key.intValue()]);
+				}
+			}
+		}
+		sb.append("];\n");
+	}
 
-        }
-        sb = new StringBuilder("digraph g");
-        sb.append(anchorNodeName);
-        sb.append(" {\n");
-        if (orientation != null && orientation != Orientation.TD){
-            sb.append("   rankdir=");
-            sb.append(orientation.toString());
-            sb.append("\n");
-        }
-        nodes = new ArrayList<String>();
-        sb.append("    label=\"");
-        if (description != null) {
-            sb.append(description);
-        }
-        else {
-            sb.append("Construct ");
-            sb.append(anchorNodeName + 1);
-        }
-        sb.append("\";\n    labelloc=top;\n    labeljust=left;\n");
+	/**
+	 * Label strings are double quoted, so they cannot contain double quotes or dot file will be invalid
+	 * @param lbl
+	 * @return
+	 */
+	private Object replaceDoubleQuotes(String lbl) {
+		if (lbl.contains("\"")) {
+			lbl = lbl.replace('\"', '\'');
+		}
+		return lbl;
+	}
 
-        nothingCount = 0;
-        graphedSubjectMap = null;
-        duplicateObjectMap = null;
+	private void applyAttributesToNode(Map<Integer, String> attributes, Object[] row, boolean anchored) {
+		boolean anchorFillColorSet = false;
+		boolean fontColorSet = false;
+		if (attributes != null) {
+			Iterator<Integer> itr = attributes.keySet().iterator();
+			while (itr.hasNext()) {
+				Integer key = itr.next();
+				String value = attributes.get(key);		
+				if (row[key.intValue()] != null) {
+					if (value.equals("fontcolor")) {
+						fontColorSet = true;
+					}
+					sb.append(" ");
+					sb.append(value);
+					sb.append("=");
+					if (anchored && value.equals("fillcolor")) {
+						sb.append("\"lightblue:");
+						anchorFillColorSet = true;
+						sb.append(row[key.intValue()]);
+						sb.append("\"");
+					}
+					else {
+						Object rval = row[key.intValue()];
+						if (needsQuotes(rval)) {
+							rval = escapeQuotes(rval.toString());
+							sb.append("\"" + rval + "\"");
+						}
+						else {
+							sb.append(rval);
+						}
+					}
+				}
+			}
+			if (anchored) {
+				if (!anchorFillColorSet) {
+					sb.append(" fillcolor=lightblue");
+					sb.append(" style=filled");
+				}
+				if (!fontColorSet) {
+					sb.append(" fontcolor=navyblue");
+				}
+			}
+		}
+	}
+	
+	private Object escapeQuotes(String str) {
+		if (str.indexOf('\"') > 0) {
+			str = str.replace("\"", "\\\"");
+		}
+		return str;
+	}
 
-        subjectList = new HashMap<Object, List<Object[]>>();
-        objectList = new HashMap<Object, List<Object[]>>();
-        while (rs.hasNext()) {
-            Object[] row = rs.next();
-            if (row[0] != null) {
-                addRowToMap(subjectList, rs.getShowNamespaces() ? row[0] : rs.extractLocalName(row[0]), row);
-//                subjectList.add(rs.getShowNamespaces() ? row[0] : rs.extractLocalName(row[0]));
-            }
-            if (row[2] != null) {
-                addRowToMap(objectList, rs.getShowNamespaces() ? row[2] : rs.extractLocalName(row[2]), row);
-//                objectList.add(rs.getShowNamespaces() ? row[2] : rs.extractLocalName(row[2]));
-            }
-        }
-        rs.first();    // reset cursor
+	/**
+	 * Method to detect if an attribute value needs to be quoted.
+	 * @param rval
+	 * @return
+	 */
+	private boolean needsQuotes(Object rval) {
+		if (rval instanceof String) {
+			if (rval.toString().indexOf(" ") >= 0) {
+				return true;
+			}
+			String str = (String)rval;
+			for(int i =0; i<str.length(); i++) {
+				char ch = str.charAt(i);
+				if (Character.isWhitespace(ch) || Character.isISOControl(ch)) {
+					return true;
+				}
+				if (ch == '.'){
+					return true;
+				} 
+				if (ch == '-') {
+					return true;
+				}
+			}		
+		}
+		return false;
+	}
 
-        while (rs.hasNext()) {
-            Object[] row = rs.next();
-            String slbl;            // name of start of directed edge
-            Object s;
-            //If this is a single node to be graphed
-            if(row[0] != null && row[1] == null && row[2] == null){
-                //is a single node
-                if (row[0].equals(OWL.Nothing.getURI())) {
-                    s = OWL.Nothing;
-                    slbl = OWL.Nothing.getLocalName() + nothingCount;
-                    nothingCount++;
-                    repeatSubjNode = false;
-                }
-                else {
-                    s = rs.getShowNamespaces() ? row[0] : rs.extractLocalName(row[0]);
-                    if (!nodes.contains(s.toString())) {
-                        nodes.add(s.toString());
-                        slbl = "n" + nodes.size();
-                        repeatSubjNode = false;
-                    }
-                    else {
-                        slbl = "n" + (nodes.indexOf(s.toString()) + 1);
-                        repeatSubjNode = true;
-                    }
-                }
-                sb.append("     ");
-                if (!repeatSubjNode) {
-                    sb.append(slbl);
-                    if(s.equals(OWL.Nothing)) {
-                        sb.append("[shape=point label=\"");
-                    }
-                    else {
-                        sb.append("[shape=box label=\"");
-                    }
-                    sb.append(s.toString());
-                    sb.append("\"");
-                    boolean anchored = false;
-                    if (anchorNodeLabel != null && s.toString().equals(anchorNodeLabel)) {
-                        anchored = true;
-                    }
-                    applyAttributesToNode(headAttributes, row, anchored);
-                    sb.append("];\n");
-                }
+	private long getSequenceNumber(Map<Integer, String> attributes, Object[] row) {
+		if (attributes != null && attributes.containsValue("sequence_number")) {
+			Iterator<Integer> keyitr = attributes.keySet().iterator();
+			while (keyitr.hasNext()) {
+				Integer key = keyitr.next();
+				String val = attributes.get(key);
+				if (val.equals("sequence_number")) {
+					Object rowval = row[key.intValue()];
+					if (rowval instanceof Long) {
+						return (long) rowval;
+					}
+					return Long.parseLong(rowval.toString());
+				}
+			}
+		}
+		return -1;
+	}
+	
+	private boolean getDuplicateAttribute(Map<Integer, String> attributes, Object[] row) {
+		if(attributes != null && 
+				attributes.containsValue("duplicate")) {
+			Iterator<Integer> keyitr = attributes.keySet().iterator();
+			while (keyitr.hasNext()) {
+				Integer key = keyitr.next();
+				String val = attributes.get(key);
+				if (val.equals("duplicate")) {
+					if(Boolean.parseBoolean((String) row[key.intValue()])) {
+						return true;
+					}
+				}
+			}
+		}
+		return false;
+	}
+	
+	private Map<Integer, String> addAttribute(Map<Integer, String> attrMap, String headName, int columnNumber, String attrHeader) {
+		String attrName = attrHeader.substring(headName.length() + 1);
+		char c = attrHeader.charAt(headName.length());
+		if (c == '_') {
+			if (attrMap == null) {
+				attrMap = new HashMap<Integer, String>();
+			}
+			attrMap.put(columnNumber, attrName);
+		}
+		return attrMap;
+	}
+	
+	private String getTempFolder() {
+		return tempFolder;
+	}
+	
+	private void setTempFolder(String tempFolder) {
+		this.tempFolder = tempFolder;
+	}
+	
+	private String getBaseFileName() {
+		return baseFileName;
+	}
+	
+	private void setBaseFileName(String baseFileName) {
+		this.baseFileName = baseFileName;
+	}
+	
+	private String getAnchorNode() {
+		return anchorNode;
+	}
+	
+	private void setAnchorNode(String anchorNode) {
+		this.anchorNode = anchorNode;
+	}
+	
+	private Orientation getOrientation() {
+		return orientation;
+	}
+	
+	private void setOrientation(Orientation orientation) {
+		this.orientation = orientation;
+	}
+	
+	private String getDescription() {
+		return description;
+	}
+	
+	private void setDescription(String description) {
+		this.description = description;
+	}
+	
+	private String getGraphName() {
+		return graphName;
+	}
+	
+	private void setGraphName(String graphName) {
+		this.graphName = graphName;
+	}
+	
+	@Override
+	public String getGraphFileToOpen() {
+		return graphFileToOpen;
+	}
 
-                continue;
-
-            }else if (row[0] == null && row[1] == null && row[2] == null) {
-                continue;
-            }
-
-            s = rs.getShowNamespaces() ? row[0] : rs.extractLocalName(row[0]);
-            String edgeLbl = rs.getShowNamespaces() ? row[1].toString() : rs.extractLocalName(row[1]);
-            Object o = rs.getShowNamespaces() ? row[2] : rs.extractLocalName(row[2]);
-
-            createGraphTriple(s, edgeLbl, o, headAttributes, edgeAttributes, tailAttributes, row, anchorNodeLabel, null);
-        }
-        if (duplicateObjectMap != null) {
-            Iterator<String> objitr = duplicateObjectMap.keySet().iterator();
-            while (objitr.hasNext()) {
-                String key = objitr.next();
-                String objnm = duplicateObjectMap.get(key);
-                if (graphedSubjectMap != null && graphedSubjectMap.containsValue(objnm) && !graphedSubjectMap.containsKey(key)) {
-                    // we need to fill out missing branches
-                    rs.first();
-                    while (rs.hasNext()) {
-                        Object[] row = rs.next();
-                        if (row[0].equals(objnm)) {
-                            Object s = rs.getShowNamespaces() ? row[0] : rs.extractLocalName(row[0]);
-                            String edgeLbl = rs.getShowNamespaces() ? row[1].toString() : rs.extractLocalName(row[1]);
-                            Object o = rs.getShowNamespaces() ? row[2] : rs.extractLocalName(row[2]);
-                            createGraphTriple(s, edgeLbl, o, headAttributes, edgeAttributes, tailAttributes, row, anchorNodeLabel, key);
-                        }
-                    }
-                }
-            }
-        }
-        sb.append("}\n");
-        File dotFile = new java.io.File(tmpdir.getAbsolutePath() + File.separator +
-                ((bfn != null ? bfn : "") + ".dot"));
-        new SadlUtils().stringToFile(dotFile, sb.toString(), false);
-        return dotFile;
-    }
-
-    private void addRowToMap(HashMap<Object, List<Object[]>> list, Object key, Object[] row) {
-        if (list.containsKey(key)) {
-            list.get(key).add(row);
-        }
-        else {
-            List<Object[]> valList = new ArrayList<Object[]>();
-            valList.add(row);
-            list.put(key, valList);
-        }
-    }
-
-    private void createGraphTriple(Object s, String edgeLbl, Object o, Map<Integer, String> headAttributes, Map<Integer, String> edgeAttributes, Map<Integer,
-            String> tailAttributes, Object[] row, String anchorNodeLabel, String subjectNode) {
-        String slbl = subjectNode;
-        String olbl;
-        if (slbl == null) {
-            if (row[0].equals(OWL.Nothing.getURI())) {
-                s = OWL.Nothing;
-                slbl = OWL.Nothing.getLocalName() + nothingCount;
-                nothingCount++;
-                repeatSubjNode = false;
-            }
-            else {
-                //check if this node should be duplicated: Used in graphing context AATIM-1389
-                boolean duplicateNode = getDuplicateAttribute(headAttributes, row);
-                long headSequenceNum = getSequenceNumber(headAttributes, row);
-                if (duplicateNode || headSequenceNum > 0) {
-                    //don't check to see if this node is in nodes
-                    nodes.add(s.toString());
-                    if (headSequenceNum > 0) {
-                        slbl = "n" + headSequenceNum;
-                    }
-                    else {
-                        slbl = "n" + nodes.size();
-                    }
-                    repeatSubjNode = false;
-                }else if (!nodes.contains(s.toString())) {
-                    nodes.add(s.toString());
-                    slbl = "n" + nodes.size();
-                    repeatSubjNode = false;
-                }
-                else {
-                    slbl = "n" + (nodes.indexOf(s.toString()) + 1);
-                    repeatSubjNode = true;
-                }
-                if (graphedSubjectMap == null) {
-                    graphedSubjectMap = new HashMap<String,String>();
-                }
-                graphedSubjectMap.put(slbl, s.toString());
-            }
-        }
-        else {
-            repeatSubjNode = true;
-        }
-        if (row[2] != null && row[2].equals(OWL.Nothing.getURI())) {
-            o = OWL.Nothing;
-            olbl = OWL.Nothing.getLocalName() + nothingCount;
-            nothingCount++;
-            repeatObjNode = false;
-        }
-        else {
-            //check if this node should be duplicated: Used in graphing context AATIM-1389
-            boolean duplicateNode = getDuplicateAttribute(tailAttributes, row);
-            long tailSequenceNum = getSequenceNumber(tailAttributes, row);
-            if(duplicateNode || tailSequenceNum > 0){
-                //don't check to see if this node is in nodes
-                nodes.add(o.toString());
-                if (tailSequenceNum > 0) {
-                    olbl = "n" + tailSequenceNum;
-                }
-                else {
-                    olbl = "n" + nodes.size();
-                }
-                repeatObjNode = false;
-                if (subjectNode == null && repeatSubjNode) {
-                    // now we want to expand out any children that this duplicate should have so it continues what's in the data...
-                    if (duplicateObjectMap == null) {
-                        duplicateObjectMap = new HashMap<String,String>();
-                    }
-                    duplicateObjectMap.put(olbl, o.toString());
-                }
-            }else if (!nodes.contains(o.toString())) {
-                nodes.add(o.toString());
-                olbl = "n" + nodes.size();
-                repeatObjNode = false;
-            }
-            else {
-                olbl = "n" + (nodes.indexOf(o.toString()) + 1);
-                repeatObjNode = true;
-            }
-        }
-        sb.append("     ");
-        if (!repeatSubjNode) {
-            sb.append(slbl);
-            if(s.equals(OWL.Nothing)) {
-                sb.append("[shape=point label=\"");
-            }
-            else {
-                sb.append("[shape=box label=\"");
-            }
-            sb.append(replaceDoubleQuotes(s.toString()));
-            sb.append("\"");
-            boolean anchored = false;
-            if (anchorNodeLabel != null && s.toString().equals(anchorNodeLabel)) {
-                anchored = true;
-            }
-            applyAttributesToNode(headAttributes, row, anchored);
-            if (objectList.containsKey(s)) {
-                List<Object[]> valList = objectList.get(s);
-                for (int i = 0; i < valList.size(); i++) {
-                    applyAttributesToNode(tailAttributes, valList.get(i), anchored);
-                }
-            }
-            sb.append("];\n");
-        }
-        if (!repeatObjNode) {
-            sb.append("     ");
-            sb.append(olbl);
-            if (o.equals(OWL.Nothing)) {
-                sb.append("[shape=point label=\"");
-            }
-            else {
-                sb.append("[shape=box label=\"");
-            }
-            sb.append(replaceDoubleQuotes(o.toString()));
-            sb.append("\"");
-            boolean anchored = false;
-            if (anchorNodeLabel != null && o.toString().equals(anchorNodeLabel)) {
-                anchored = true;
-            }
-            applyAttributesToNode(tailAttributes, row, anchored);
-            if (subjectList.containsKey(o)) {
-                List<Object[]> valList = subjectList.get(o);
-                for (int i = 0; i < valList.size(); i++) {
-                    applyAttributesToNode(headAttributes, valList.get(i), anchored);
-                }
-            }
-            sb.append("];\n");
-        }
-        sb.append("     ");
-        sb.append(slbl);
-        sb.append("->");
-        sb.append(olbl);
-        sb.append("[");
-        boolean anchored = false;
-        if (row[1] != null && row[1].toString().length() > 0) {
-            if (anchorNodeLabel != null && edgeLbl.equals(anchorNodeLabel)) {
-                anchored = true;
-            }
-            sb.append("label=\"");
-            sb.append(replaceDoubleQuotes(edgeLbl));
-            sb.append("\"");
-            // color the "anchor" edge
-            if (anchored) {
-                sb.append(" style=bold");
-            }
-        }
-        if (edgeAttributes != null) {
-            Iterator<Integer> itr = edgeAttributes.keySet().iterator();
-            while (itr.hasNext()) {
-                Integer key = itr.next();
-                String value = edgeAttributes.get(key);
-                if (anchored && value.equals("style")) {
-                    continue; // already set
-                }
-                if (row[key.intValue()] != null) {
-                    sb.append(" ");
-                    sb.append(value);
-                    sb.append("=");
-                    sb.append(row[key.intValue()]);
-                }
-            }
-        }
-        sb.append("];\n");
-    }
-
-    /**
-     * Label strings are double quoted, so they cannot contain double quotes or dot file will be invalid
-     * @param lbl
-     * @return
-     */
-    private Object replaceDoubleQuotes(String lbl) {
-        if (lbl.contains("\"")) {
-            lbl = lbl.replace('\"', '\'');
-        }
-        return lbl;
-    }
-
-    private void applyAttributesToNode(Map<Integer, String> attributes, Object[] row, boolean anchored) {
-        boolean anchorFillColorSet = false;
-        boolean fontColorSet = false;
-        if (attributes != null) {
-            Iterator<Integer> itr = attributes.keySet().iterator();
-            while (itr.hasNext()) {
-                Integer key = itr.next();
-                String value = attributes.get(key);
-                if (row[key.intValue()] != null) {
-                    if (value.equals("fontcolor")) {
-                        fontColorSet = true;
-                    }
-                    sb.append(" ");
-                    sb.append(value);
-                    sb.append("=");
-                    if (anchored && value.equals("fillcolor")) {
-                        sb.append("\"lightblue:");
-                        anchorFillColorSet = true;
-                        sb.append(row[key.intValue()]);
-                        sb.append("\"");
-                    }
-                    else {
-                        Object rval = row[key.intValue()];
-                        if (needsQuotes(rval)) {
-                            rval = escapeQuotes(rval.toString());
-                            sb.append("\"" + rval + "\"");
-                        }
-                        else {
-                            sb.append(rval);
-                        }
-                    }
-                }
-            }
-            if (anchored) {
-                if (!anchorFillColorSet) {
-                    sb.append(" fillcolor=lightblue");
-                    sb.append(" style=filled");
-                }
-                if (!fontColorSet) {
-                    sb.append(" fontcolor=navyblue");
-                }
-            }
-        }
-    }
-
-    private Object escapeQuotes(String str) {
-        if (str.indexOf('\"') > 0) {
-            str = str.replace("\"", "\\\"");
-        }
-        return str;
-    }
-
-    /**
-     * Method to detect if an attribute value needs to be quoted.
-     * @param rval
-     * @return
-     */
-    private boolean needsQuotes(Object rval) {
-        if (rval instanceof String) {
-            if (rval.toString().indexOf(" ") >= 0) {
-                return true;
-            }
-            String str = (String)rval;
-            for(int i =0; i<str.length(); i++) {
-                char ch = str.charAt(i);
-                if (Character.isWhitespace(ch) || Character.isISOControl(ch)) {
-                    return true;
-                }
-                if (ch == '.'){
-                    return true;
-                }
-                if (ch == '-') {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    private long getSequenceNumber(Map<Integer, String> attributes, Object[] row) {
-        if (attributes != null && attributes.containsValue("sequence_number")) {
-            Iterator<Integer> keyitr = attributes.keySet().iterator();
-            while (keyitr.hasNext()) {
-                Integer key = keyitr.next();
-                String val = attributes.get(key);
-                if (val.equals("sequence_number")) {
-                    Object rowval = row[key.intValue()];
-                    if (rowval instanceof Long) {
-                        return (long) rowval;
-                    }
-                    return Long.parseLong(rowval.toString());
-                }
-            }
-        }
-        return -1;
-    }
-
-    private boolean getDuplicateAttribute(Map<Integer, String> attributes, Object[] row) {
-        if(attributes != null &&
-                attributes.containsValue("duplicate")) {
-            Iterator<Integer> keyitr = attributes.keySet().iterator();
-            while (keyitr.hasNext()) {
-                Integer key = keyitr.next();
-                String val = attributes.get(key);
-                if (val.equals("duplicate")) {
-                    if(Boolean.parseBoolean((String) row[key.intValue()])) {
-                        return true;
-                    }
-                }
-            }
-        }
-        return false;
-    }
-
-    private Map<Integer, String> addAttribute(Map<Integer, String> attrMap, String headName, int columnNumber, String attrHeader) {
-        String attrName = attrHeader.substring(headName.length() + 1);
-        char c = attrHeader.charAt(headName.length());
-        if (c == '_') {
-            if (attrMap == null) {
-                attrMap = new HashMap<Integer, String>();
-            }
-            attrMap.put(columnNumber, attrName);
-        }
-        return attrMap;
-    }
-
-    private String getTempFolder() {
-        return tempFolder;
-    }
-
-    private void setTempFolder(String tempFolder) {
-        this.tempFolder = tempFolder;
-    }
-
-    private String getBaseFileName() {
-        return baseFileName;
-    }
-
-    private void setBaseFileName(String baseFileName) {
-        this.baseFileName = baseFileName;
-    }
-
-    private String getAnchorNode() {
-        return anchorNode;
-    }
-
-    private void setAnchorNode(String anchorNode) {
-        this.anchorNode = anchorNode;
-    }
-
-    private Orientation getOrientation() {
-        return orientation;
-    }
-
-    private void setOrientation(Orientation orientation) {
-        this.orientation = orientation;
-    }
-
-    private String getDescription() {
-        return description;
-    }
-
-    private void setDescription(String description) {
-        this.description = description;
-    }
-
-    private String getGraphName() {
-        return graphName;
-    }
-
-    private void setGraphName(String graphName) {
-        this.graphName = graphName;
-    }
-
-    @Override
-    public String getGraphFileToOpen() {
-        return graphFileToOpen;
-    }
-
-    @Override
-    public String getGraphFilenameExtension() {
-        return ".svg";
-    }
+	@Override
+	public String getGraphFilenameExtension() {
+		return ".svg";
+	}
 }

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui/src/com/ge/research/sadl/ui/handlers/SadlActionHandler.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui/src/com/ge/research/sadl/ui/handlers/SadlActionHandler.java
@@ -79,7 +79,7 @@ import org.slf4j.LoggerFactory;
 @SuppressWarnings("restriction")
 public abstract class SadlActionHandler extends AbstractHandler {
 
-	private final Logger logger = LoggerFactory.getLogger(SadlActionHandler.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(SadlActionHandler.class);
 	private boolean isCanceled = false;
 	@Inject
 	protected IResourceSetProvider resourceSetProvider;
@@ -162,7 +162,7 @@ public abstract class SadlActionHandler extends AbstractHandler {
 	    		        	}
 	    				}
 	    			} catch (Throwable e) {
-	    				logger.error("Ignoring " + e, e);
+	    				LOGGER.error("Ignoring " + e, e);
 	    			}
 	            }
 	        }
@@ -452,7 +452,7 @@ public abstract class SadlActionHandler extends AbstractHandler {
 						}
 					}
 				} catch (IOException e) {
-					logger.error("Ignoring " + e, e);
+					LOGGER.error("Ignoring " + e, e);
 				}
 			}
 		});

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui/src/com/ge/research/sadl/ui/handlers/SadlActionHandler.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui/src/com/ge/research/sadl/ui/handlers/SadlActionHandler.java
@@ -79,440 +79,441 @@ import org.slf4j.LoggerFactory;
 @SuppressWarnings("restriction")
 public abstract class SadlActionHandler extends AbstractHandler {
 
-    private final Logger logger = LoggerFactory.getLogger(SadlActionHandler.class);
-    private boolean isCanceled = false;
-    @Inject
-    protected IResourceSetProvider resourceSetProvider;
-    @Inject
-    protected SadlInferenceProcessorProvider processorProvider;
-    @Inject
-    protected IPreferenceValuesProvider preferenceProvider;
-    @Inject
-    protected SadlConsole console;
+	private final Logger logger = LoggerFactory.getLogger(SadlActionHandler.class);
+	private boolean isCanceled = false;
+	@Inject
+	protected IResourceSetProvider resourceSetProvider;
+	@Inject
+	protected SadlInferenceProcessorProvider processorProvider;
+	@Inject
+	protected IPreferenceValuesProvider preferenceProvider;
+	@Inject
+	protected SadlConsole console;
+	
+	protected ISadlInferenceProcessor processor;
+	
+	private IGraphVisualizer visualizer = null;
+	
+	protected abstract String[] getValidTargetFileTypes();
 
-    protected ISadlInferenceProcessor processor;
+	protected Object[] getCommandTarget(String[] validTargetTypes) throws TranslationException {
+		IProject project = null;
+		IPath trgtFolder = null;
+		IFile trgtFile = null;
+		EObject selectedConcept = null;
+		IPath prjFolder;
 
-    private IGraphVisualizer visualizer = null;
+		IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+	    if (window != null)
+	    {
+	        ISelection selection = (ISelection) window.getSelectionService().getSelection();
+	        if (!(selection instanceof IStructuredSelection)) {
+	    		IWorkbenchPage page =  window.getActivePage();
+	    		IEditorPart editorPart = page.getActiveEditor();
+	    		if (editorPart.isDirty()) {
+	    		    console.print(MessageType.ERROR, "Model has unsaved changes. Please save before running tests.\n");
+	    		    return null;
+	    		}
+	    		IEditorInput iei = editorPart.getEditorInput();
+	    		if (iei instanceof FileEditorInput) {
+	    			trgtFile = ((FileEditorInput)iei).getFile();
+	    			trgtFolder = trgtFile.getFullPath().removeLastSegments(1);
+	    			IContainer prnt = null;
+	    			do {
+	    				prnt = prnt == null ? trgtFile.getParent() : prnt.getParent();
+	    			} while (prnt != null && !(prnt instanceof IProject));
+	    			if (prnt != null) {
+	    				project = ((IProject)prnt).getProject();
+	    			}
+	    			trgtFolder = trgtFile.getFullPath().removeLastSegments(1);
+	    		}
+	    		else {
+	    			System.err.println("No project is selected for action");
+		        	return null;
+	    		}
+	            if (editorPart instanceof XtextEditor) {
+	                ISelection sel = editorPart.getEditorSite().getSelectionProvider().getSelection();
+	                try {
+	    				if (sel instanceof TextSelection) {
+	    					int offset = ((TextSelection)sel).getOffset();
+	    					int length = ((TextSelection)sel).getLength();
+	    		        	String seltxt = ((XtextEditor)editorPart).getDocument().get(offset, length);
+	    		        	if (seltxt != null && seltxt.length() > 0) {
+	    		        		final TextSelection xtsel = (TextSelection) sel;
+	    		                IXtextDocument document = ((XtextEditor)editorPart).getDocument();
+	    		                EObject selectedObject = document.readOnly(new IUnitOfWork<EObject, XtextResource>() {            
+	    		                    public EObject exec(XtextResource resource) throws Exception {
+	    		                      IParseResult parseResult = resource.getParseResult();
+	    		                            if (parseResult == null) {
+	    		                              return null;
+	    		                            }
+	    		                            ICompositeNode rootNode = parseResult.getRootNode();
+	    		                            int offset = xtsel.getOffset();
+	    		                            ILeafNode node = NodeModelUtils.findLeafNodeAtOffset(rootNode, offset);
+	    		                            return NodeModelUtils.findActualSemanticObjectFor(node);
+	    		                    }
+	    		                });	
+	    		        		if (selectedObject != null) {
+    		    					selectedConcept = selectedObject;
+    		    				}
+    		    				else {
+    		    					console.error("Unable to find a concept with name '" + seltxt + "'");
+    		    				}
+	    		        	}
+	    				}
+	    			} catch (Throwable e) {
+	    				logger.error("Ignoring " + e, e);
+	    			}
+	            }
+	        }
+	        else {
+		        Object firstElement = ((IStructuredSelection)selection).getFirstElement();
+		        if (firstElement instanceof IAdaptable)
+		        {
+		        	if (firstElement instanceof org.eclipse.core.resources.IFile) {
+	        			trgtFile = (IFile) firstElement;
+	        			trgtFolder =  ((org.eclipse.core.resources.IFile)firstElement).getParent().getFullPath();	
+	        			project = ((org.eclipse.core.resources.IFile)firstElement).getProject();
+	        			prjFolder = project.getFullPath();
+		        		boolean validType = false;
+		        		for (int i = 0; validTargetTypes != null && i < validTargetTypes.length; i++) {
+		        			if (((org.eclipse.core.resources.IFile)firstElement).getFileExtension().equals(validTargetTypes[i])) {
+		        				validType = true;
+		        				break;
+		        			}
+//		        			else if (validTargetTypes[i].equals("owl")) {
+//		        				// a type of owl is also valid for any file that has a derived (same base name) .owl file in the OwlModels folder--return the file
+//		        				String owlFileName = convertProjectRelativePathToAbsolutePath(
+//		        						project.getFullPath().append(ResourceManager.OWLDIR).append(trgtFile.getFullPath().removeFileExtension().addFileExtension("owl").lastSegment()).toPortableString());
+//		        				if (new File(owlFileName).exists()) {
+//		        					validType = true;
+//		        					break;
+//		        				}
+//		        				else {
+//		        					owlFileName = convertProjectRelativePathToAbsolutePath(
+//			        						project.getFullPath().append(ResourceManager.OWLDIR).append(trgtFile.getFullPath().addFileExtension("owl").lastSegment()).toPortableString());
+//			        				if (new File(owlFileName).exists()) {
+//			        					validType = true;
+//			        					break;
+//			        				}
+//		        				}
+//		        			}
+		        		}
+		        		if (!validType) {
+		        			StringBuilder sb = new StringBuilder();
+		        			if (validTargetTypes == null) {
+		        				sb.append("No valid file types for this command. Select a folder or project");
+		        			}
+		        			else {
+		        				for (int i = 0; i < validTargetTypes.length; i++) {
+		        					if (i > 0) sb.append(", ");
+			        				sb.append(validTargetTypes[i]);
+		        				}
+		        			}
+		        			throw new TranslationException(SadlErrorMessages.FILE_TYPE_ERROR.get(sb.toString()));
+		        		}
+		        	}
+		        	else if (firstElement instanceof IFolder) {
+		        		trgtFolder = ((IFolder)firstElement).getFullPath();
+	        			prjFolder = ((IFolder)firstElement).getProject().getFullPath();
+		        	}
+		        	else if (firstElement instanceof IProject) {
+		        		project = (IProject) firstElement;
+		        		prjFolder = ((IProject)firstElement).getFullPath();
+		        		trgtFolder = prjFolder;
+		        	}
+		        	else {
+		        		// project?
+		        		project = (IProject)((IAdaptable)firstElement).getAdapter(IProject.class);
+			            if (project == null) {
+			            	if (firstElement instanceof org.eclipse.core.resources.IFile) {
+			            		project = ((org.eclipse.core.resources.IFile)firstElement).getProject();
+			            	}
+			            	else if (firstElement instanceof IFolder) {
+			            		project = ((IFolder)firstElement).getProject();
+			            	}
+			            	else {
+			            		throw new TranslationException("Unable to identify file, folder, or project to translate");
+			            	}
+			            }
+			            IPath path = project.getFullPath();
+			            prjFolder = path;
+			            trgtFolder = prjFolder;
+		        	}
+		        }
+	        }
+	        if (project != null || trgtFolder != null || trgtFile != null) {
+	     		Object[] results = new Object[4];
+	    		results[0] = project;
+	   			results[1] = trgtFolder;
+	     		results[2] = trgtFile;
+	     		results[3] = selectedConcept;
+	    		return results;
+	        }
+	        else {
+	        	return null;
+	        }
+	    }
+	    throw new TranslationException("Nothing selected, unable to process command");
+	}
+	
+	protected IFile getTargetFile(String[] validTargetTypes) throws ExecutionException {
+			IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+			if (window != null) {
+			    ISelection selection = (ISelection) window.getSelectionService().getSelection();
+			    if (selection instanceof TextSelection) {
+			    	XtextEditor editor = EditorUtils.getActiveXtextEditor();
+			    	if (editor != null) {
+				    	IEditorInput editorInput = editor.getEditorInput();
+				    	if (editorInput instanceof IFileEditorInput) {
+				    		return ((IFileEditorInput) editorInput).getFile();
+				    	}
+			    	}
+			    }
+			    if (!(selection instanceof IStructuredSelection) || selection.isEmpty()) {
+			    	throw new ExecutionException("Nothing is selected for action");
+			    }
+			    Object firstElement = ((IStructuredSelection)selection).getFirstElement();
+			    if (firstElement instanceof IAdaptable)
+			    {
+			    	if (firstElement instanceof org.eclipse.core.resources.IFile) {
+			    		String ext = ((org.eclipse.core.resources.IFile)firstElement).getFileExtension();
+			    		boolean validTarget = false;
+			    		for (String s : validTargetTypes) {
+			    			if (s.equals(ext)) {
+			    				validTarget = true;
+			    				break;
+			    			}
+			    		}
+			    		if (validTarget) {
+			    			return  (IFile) firstElement;	
+			    		}
+			    		else {
+			    			throw new ExecutionException("Only files of type .sadl or .test can be targets for this action");
+			    		}
+			    	}
+			    	else {
+			    		throw new ExecutionException("A valid target file must be selected");
+			    	}
+			    }
+			}
+			throw new ExecutionException("No project window selected");
+		}
+	
+	protected Map<String, String> getPreferences(IFile file) {
+		final URI uri = URI.createPlatformResourceURI(file.getFullPath().toString(), true);
+		return getPreferences(uri);
+	}
+	
+	protected Map<String, String> getPreferences(URI uri) {
+		Injector reqInjector = safeGetInjector(SadlActivator.COM_GE_RESEARCH_SADL_SADL);
+		IPreferenceValuesProvider pvp = reqInjector.getInstance(IPreferenceValuesProvider.class);
+		IPreferenceValues preferenceValues = pvp.getPreferenceValues(new XtextResource(uri));
+		if (preferenceValues != null) {
+			Map<String, String> map = new HashMap<String, String>();
+			boolean bval = Boolean.parseBoolean(preferenceValues.getPreference(SadlPreferences.SHOW_TIMING_INFORMATION));
+			if (bval) {
+				map.put(SadlPreferences.SHOW_TIMING_INFORMATION.getId(), "true");
+			}
+			else {
+				map.put(SadlPreferences.SHOW_TIMING_INFORMATION.getId(), "false");
+			}
+			bval = Boolean.parseBoolean(preferenceValues.getPreference(SadlPreferences.VALIDATE_BEFORE_TEST));
+			if (bval) {
+				map.put(SadlPreferences.VALIDATE_BEFORE_TEST.getId(), "true");
+			}
+			else {
+				map.put(SadlPreferences.VALIDATE_BEFORE_TEST.getId(), "false");
+			}
+			bval = Boolean.parseBoolean(preferenceValues.getPreference(SadlPreferences.NAMESPACE_IN_QUERY_RESULTS));
+			if (bval) {
+				map.put(SadlPreferences.NAMESPACE_IN_QUERY_RESULTS.getId(), "true");
+			}
+			else {
+				map.put(SadlPreferences.NAMESPACE_IN_QUERY_RESULTS.getId(), "false");
+			}
+//			preferenceValues.getPreference(SadlPreferences.)
+			return map;
+		}
+		return null;
+	}
 
-    protected abstract String[] getValidTargetFileTypes();
+	protected final Injector safeGetInjector(String name){
+		final AtomicReference<Injector> i = new AtomicReference<Injector>();
+		Display.getDefault().syncExec(new Runnable(){
+			@Override
+			public void run() {
+				i.set(SadlActivator.getInstance().getInjector(name));
+			}
+		});
+		
+		return i.get();
+	}
 
-    protected Object[] getCommandTarget(String[] validTargetTypes) throws TranslationException {
-        IProject project = null;
-        IPath trgtFolder = null;
-        IFile trgtFile = null;
-        EObject selectedConcept = null;
-        IPath prjFolder;
+	public static String convertProjectRelativePathToAbsolutePath(String relPath) {
+		IWorkspace workspace = ResourcesPlugin.getWorkspace();
+		IWorkspaceRoot root = workspace.getRoot();
+		IPath path = root.getFile(new Path(relPath)).getLocation();
+		String absolutePath = path.toString();
+		return absolutePath;
+	}
 
-        IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
-        if (window != null)
-        {
-            ISelection selection = (ISelection) window.getSelectionService().getSelection();
-            if (!(selection instanceof IStructuredSelection)) {
-                IWorkbenchPage page =  window.getActivePage();
-                IEditorPart editorPart = page.getActiveEditor();
-                if (editorPart.isDirty()) {
-                    console.print(MessageType.ERROR, "Model has unsaved changes. Please save before running tests.\n");
-                    return null;
-                }
-                IEditorInput iei = editorPart.getEditorInput();
-                if (iei instanceof FileEditorInput) {
-                    trgtFile = ((FileEditorInput)iei).getFile();
-                    trgtFolder = trgtFile.getFullPath().removeLastSegments(1);
-                    IContainer prnt = null;
-                    do {
-                        prnt = prnt == null ? trgtFile.getParent() : prnt.getParent();
-                    } while (prnt != null && !(prnt instanceof IProject));
-                    if (prnt != null) {
-                        project = ((IProject)prnt).getProject();
-                    }
-                    trgtFolder = trgtFile.getFullPath().removeLastSegments(1);
-                }
-                else {
-                    System.err.println("No project is selected for action");
-                    return null;
-                }
-                if (editorPart instanceof XtextEditor) {
-                    ISelection sel = editorPart.getEditorSite().getSelectionProvider().getSelection();
-                    try {
-                        if (sel instanceof TextSelection) {
-                            int offset = ((TextSelection)sel).getOffset();
-                            int length = ((TextSelection)sel).getLength();
-                            String seltxt = ((XtextEditor)editorPart).getDocument().get(offset, length);
-                            if (seltxt != null && seltxt.length() > 0) {
-                                final TextSelection xtsel = (TextSelection) sel;
-                                IXtextDocument document = ((XtextEditor)editorPart).getDocument();
-                                EObject selectedObject = document.readOnly(new IUnitOfWork<EObject, XtextResource>() {
-                                    public EObject exec(XtextResource resource) throws Exception {
-                                      IParseResult parseResult = resource.getParseResult();
-                                            if (parseResult == null) {
-                                              return null;
-                                            }
-                                            ICompositeNode rootNode = parseResult.getRootNode();
-                                            int offset = xtsel.getOffset();
-                                            ILeafNode node = NodeModelUtils.findLeafNodeAtOffset(rootNode, offset);
-                                            return NodeModelUtils.findActualSemanticObjectFor(node);
-                                    }
-                                });
-                                if (selectedObject != null) {
-                                    selectedConcept = selectedObject;
-                                }
-                                else {
-                                    console.error("Unable to find a concept with name '" + seltxt + "'");
-                                }
-                            }
-                        }
-                    } catch (Throwable e) {
-                        logger.error("Ignoring " + e, e);
-                    }
-                }
-            }
-            else {
-                Object firstElement = ((IStructuredSelection)selection).getFirstElement();
-                if (firstElement instanceof IAdaptable)
-                {
-                    if (firstElement instanceof org.eclipse.core.resources.IFile) {
-                        trgtFile = (IFile) firstElement;
-                        trgtFolder =  ((org.eclipse.core.resources.IFile)firstElement).getParent().getFullPath();
-                        project = ((org.eclipse.core.resources.IFile)firstElement).getProject();
-                        prjFolder = project.getFullPath();
-                        boolean validType = false;
-                        for (int i = 0; validTargetTypes != null && i < validTargetTypes.length; i++) {
-                            if (((org.eclipse.core.resources.IFile)firstElement).getFileExtension().equals(validTargetTypes[i])) {
-                                validType = true;
-                                break;
-                            }
-//                            else if (validTargetTypes[i].equals("owl")) {
-//                                // a type of owl is also valid for any file that has a derived (same base name) .owl file in the OwlModels folder--return the file
-//                                String owlFileName = convertProjectRelativePathToAbsolutePath(
-//                                        project.getFullPath().append(ResourceManager.OWLDIR).append(trgtFile.getFullPath().removeFileExtension().addFileExtension("owl").lastSegment()).toPortableString());
-//                                if (new File(owlFileName).exists()) {
-//                                    validType = true;
-//                                    break;
-//                                }
-//                                else {
-//                                    owlFileName = convertProjectRelativePathToAbsolutePath(
-//                                            project.getFullPath().append(ResourceManager.OWLDIR).append(trgtFile.getFullPath().addFileExtension("owl").lastSegment()).toPortableString());
-//                                    if (new File(owlFileName).exists()) {
-//                                        validType = true;
-//                                        break;
-//                                    }
-//                                }
-//                            }
-                        }
-                        if (!validType) {
-                            StringBuilder sb = new StringBuilder();
-                            if (validTargetTypes == null) {
-                                sb.append("No valid file types for this command. Select a folder or project");
-                            }
-                            else {
-                                for (int i = 0; i < validTargetTypes.length; i++) {
-                                    if (i > 0) sb.append(", ");
-                                    sb.append(validTargetTypes[i]);
-                                }
-                            }
-                            throw new TranslationException(SadlErrorMessages.FILE_TYPE_ERROR.get(sb.toString()));
-                        }
-                    }
-                    else if (firstElement instanceof IFolder) {
-                        trgtFolder = ((IFolder)firstElement).getFullPath();
-                        prjFolder = ((IFolder)firstElement).getProject().getFullPath();
-                    }
-                    else if (firstElement instanceof IProject) {
-                        project = (IProject) firstElement;
-                        prjFolder = ((IProject)firstElement).getFullPath();
-                        trgtFolder = prjFolder;
-                    }
-                    else {
-                        // project?
-                        project = (IProject)((IAdaptable)firstElement).getAdapter(IProject.class);
-                        if (project == null) {
-                            if (firstElement instanceof org.eclipse.core.resources.IFile) {
-                                project = ((org.eclipse.core.resources.IFile)firstElement).getProject();
-                            }
-                            else if (firstElement instanceof IFolder) {
-                                project = ((IFolder)firstElement).getProject();
-                            }
-                            else {
-                                throw new TranslationException("Unable to identify file, folder, or project to translate");
-                            }
-                        }
-                        IPath path = project.getFullPath();
-                        prjFolder = path;
-                        trgtFolder = prjFolder;
-                    }
-                }
-            }
-            if (project != null || trgtFolder != null || trgtFile != null) {
-                 Object[] results = new Object[4];
-                results[0] = project;
-                   results[1] = trgtFolder;
-                 results[2] = trgtFile;
-                 results[3] = selectedConcept;
-                return results;
-            }
-            else {
-                return null;
-            }
-        }
-        throw new TranslationException("Nothing selected, unable to process command");
-    }
+	protected boolean isCanceled() {
+		return isCanceled;
+	}
 
-    protected IFile getTargetFile(String[] validTargetTypes) throws ExecutionException {
-            IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
-            if (window != null) {
-                ISelection selection = (ISelection) window.getSelectionService().getSelection();
-                if (selection instanceof TextSelection) {
-                    XtextEditor editor = EditorUtils.getActiveXtextEditor();
-                    if (editor != null) {
-                        IEditorInput editorInput = editor.getEditorInput();
-                        if (editorInput instanceof IFileEditorInput) {
-                            return ((IFileEditorInput) editorInput).getFile();
-                        }
-                    }
-                }
-                if (!(selection instanceof IStructuredSelection) || selection.isEmpty()) {
-                    throw new ExecutionException("Nothing is selected for action");
-                }
-                Object firstElement = ((IStructuredSelection)selection).getFirstElement();
-                if (firstElement instanceof IAdaptable)
-                {
-                    if (firstElement instanceof org.eclipse.core.resources.IFile) {
-                        String ext = ((org.eclipse.core.resources.IFile)firstElement).getFileExtension();
-                        boolean validTarget = false;
-                        for (String s : validTargetTypes) {
-                            if (s.equals(ext)) {
-                                validTarget = true;
-                                break;
-                            }
-                        }
-                        if (validTarget) {
-                            return  (IFile) firstElement;
-                        }
-                        else {
-                            throw new ExecutionException("Only files of type .sadl or .test can be targets for this action");
-                        }
-                    }
-                    else {
-                        throw new ExecutionException("A valid target file must be selected");
-                    }
-                }
-            }
-            throw new ExecutionException("No project window selected");
-        }
+	protected void setCanceled(boolean isCanceled) {
+		this.isCanceled = isCanceled;
+	}
 
-    protected Map<String, String> getPreferences(IFile file) {
-        final URI uri = URI.createPlatformResourceURI(file.getFullPath().toString(), true);
-        return getPreferences(uri);
-    }
+	protected Resource prepareActionHandler(IProject project, IFile trgtFile) throws ExecutionException {	
+		XtextResource res = getXtextResource(project, trgtFile);
+    	if (res != null) {
+    		if (res instanceof XtextResource) {
+	    		IResourceValidator validator = res.getResourceServiceProvider().getResourceValidator();
+	    		validator.validate(res, CheckMode.FAST_ONLY, CancelIndicator.NullImpl);
+				processor = processorProvider.getProcessor(res);
+    		}
+			return res;
+    	}
+    	else {
+			throw new ExecutionException("Unable to obtain a resource for the target file '" + trgtFile.getName() + "'");
+		}
+	}
+	
+	protected XtextResource getXtextResource(IProject project, IFile trgtFile) throws ExecutionException {
+		ResourceSet resourceSet = resourceSetProvider.get(project);
+		if (resourceSet != null) {
+	    	Resource res = resourceSet.getResource(URI.createPlatformResourceURI(trgtFile.getFullPath().toString(), true), true);
+	    	if (res != null) {
+	    		if (res instanceof XtextResource) {
+	    			return (XtextResource) res;
+	    		}
+	    	}
+		}
+		else {
+			throw new ExecutionException("Unable to obtain a resource set for the target file '" + trgtFile.getName() + "'");
+		}
+		return null;
+	}
 
-    protected Map<String, String> getPreferences(URI uri) {
-        Injector reqInjector = safeGetInjector(SadlActivator.COM_GE_RESEARCH_SADL_SADL);
-        IPreferenceValuesProvider pvp = reqInjector.getInstance(IPreferenceValuesProvider.class);
-        IPreferenceValues preferenceValues = pvp.getPreferenceValues(new XtextResource(uri));
-        if (preferenceValues != null) {
-            Map<String, String> map = new HashMap<String, String>();
-            boolean bval = Boolean.parseBoolean(preferenceValues.getPreference(SadlPreferences.SHOW_TIMING_INFORMATION));
-            if (bval) {
-                map.put(SadlPreferences.SHOW_TIMING_INFORMATION.getId(), "true");
-            }
-            else {
-                map.put(SadlPreferences.SHOW_TIMING_INFORMATION.getId(), "false");
-            }
-            bval = Boolean.parseBoolean(preferenceValues.getPreference(SadlPreferences.VALIDATE_BEFORE_TEST));
-            if (bval) {
-                map.put(SadlPreferences.VALIDATE_BEFORE_TEST.getId(), "true");
-            }
-            else {
-                map.put(SadlPreferences.VALIDATE_BEFORE_TEST.getId(), "false");
-            }
-            bval = Boolean.parseBoolean(preferenceValues.getPreference(SadlPreferences.NAMESPACE_IN_QUERY_RESULTS));
-            if (bval) {
-                map.put(SadlPreferences.NAMESPACE_IN_QUERY_RESULTS.getId(), "true");
-            }
-            else {
-                map.put(SadlPreferences.NAMESPACE_IN_QUERY_RESULTS.getId(), "false");
-            }
-//            preferenceValues.getPreference(SadlPreferences.)
-            return map;
-        }
-        return null;
-    }
+	protected IGraphVisualizer getVisualizer(IConfigurationManagerForEditing configMgr, Map<String,String> prefMap) {
+		if (visualizer == null) {
+			String renderClass = prefMap.get(SadlPreferences.GRAPH_RENDERER_CLASS.getId());
+			List<IGraphVisualizer> visualizers = configMgr.getAvailableGraphRenderers();
+					
+			if (visualizers != null && visualizers.size() > 0) {
+				visualizer = visualizers.get(0);		// replace this by selection and setting preference
+				for (IGraphVisualizer igv : visualizers) {
+					if (igv.getClass().getCanonicalName().equals(renderClass)) {
+						visualizer = igv;
+						break;
+					}
+				}
+			}
+		}
+		return visualizer;	
+	}
 
-    protected final Injector safeGetInjector(String name){
-        final AtomicReference<Injector> i = new AtomicReference<Injector>();
-        Display.getDefault().syncExec(new Runnable(){
-            @Override
-            public void run() {
-                i.set(SadlActivator.getInstance().getInjector(name));
-            }
-        });
+	protected void graphResultSet(IGraphVisualizer iGraphVisualizer, IProject project, String baseFileName, String graphName, String anchorNode,
+			String description, ResultSet rs, IGraphVisualizer.Orientation orientation, boolean openGraph) throws IOException {
+		if (orientation == null) {
+			orientation = IGraphVisualizer.Orientation.TD;
+		}
+		final IGraphVisualizer.Orientation innerOrientation = orientation;
+		String tempDir = convertProjectRelativePathToAbsolutePath(getGraphDir(project)); 
+		File tmpDirFile = new File(tempDir);
+		tmpDirFile.mkdirs();
+		
+		//Perform UI operations from background thread
+		Display.getDefault().asyncExec(new Runnable(){
+			@Override
+			public void run(){
+				try {
+					iGraphVisualizer.initialize(tempDir, baseFileName, graphName, anchorNode, innerOrientation, description);
+					iGraphVisualizer.graphResultSetData(rs);
+					if (openGraph) {
+						String fileToOpen = iGraphVisualizer.getGraphFileToOpen();
+						if (fileToOpen != null) {
+							File fto = new File(fileToOpen);
+							if (fto.isFile()) {
+								IFileStore fileStore = EFS.getLocalFileSystem().getStore(fto.toURI());
+								IWorkbenchPage page = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
+								try {
+									IDE.openEditorOnFileStore(page, fileStore);
+								}
+								catch (Throwable t) {
+									console.error("Error trying to display graph file '" + fileToOpen + "': " + t.getMessage());
+								}
+							}
+							else if (fileToOpen != null) {
+								console.error("Failed to open graph file '" + fileToOpen + "'. Try opening it manually.");
+							}
+						}
+					}
+				} catch (IOException e) {
+					logger.error("Ignoring " + e, e);
+				}
+			}
+		});
+		
+	}
 
-        return i.get();
-    }
+	public static String getGraphDir(IProject project) {
+		return project.getFullPath().append("Graphs").toPortableString();
+	}
+	
+	protected void createGraphFromResultSet(IGraphVisualizer iGraphVisualizer, IProject project, IFile trgtFile, String baseFileName, String graphName, String anchorNode,
+			String description, ResultSet rs) throws IOException {
+		String tempDir = convertProjectRelativePathToAbsolutePath(getGraphDir(project)); 
+		File tmpDirFile = new File(tempDir);
+		tmpDirFile.mkdirs();
+		iGraphVisualizer.initialize(tempDir, baseFileName, graphName, anchorNode, IGraphVisualizer.Orientation.TD, description);
+		iGraphVisualizer.graphResultSetData(rs);
+	}
+	
+	protected void resultSetToGraph(IProject project, IFile trgtFile, ResultSet rs, String desc, String baseFileName, 
+			Orientation orientation, Map<String,String> prefMap)
+			throws ConfigurationException, IOException {
+		if (rs.getColumnCount() >= 3) {
+			String modelFolderUri = convertProjectRelativePathToAbsolutePath(project.getFullPath().append(ResourceManager.OWLDIR).toPortableString()); 
+			final String format = ConfigurationManager.RDF_XML_ABBREV_FORMAT;
+			IConfigurationManagerForIDE configMgr = ConfigurationManagerForIdeFactory.getConfigurationManagerForIDE(modelFolderUri, format);
+	
+			IGraphVisualizer visualizer = getVisualizer(configMgr, prefMap);
+			if (visualizer != null) {
+				graphResultSet(visualizer, project, baseFileName, baseFileName, null, desc, rs, orientation, true);
+			}
+			else {
+				console.error("Unable to find an instance of IGraphVisualizer to render graph for query.\n");
+			}
+		}
+		else {
+			console.error("Unable to render graph for query; ResultSet has less than 3 columns.\n");
+		}
+	}
+	
+	public class SadlEclipseGraphVisualizerHandler implements SadlGraphVisualizerHandler {
+		
+		private SadlActionHandler uiHandler;
+		private IProject project;
+		private IFile targetFile;
 
-    public static String convertProjectRelativePathToAbsolutePath(String relPath) {
-        IWorkspace workspace = ResourcesPlugin.getWorkspace();
-        IWorkspaceRoot root = workspace.getRoot();
-        IPath path = root.getFile(new Path(relPath)).getLocation();
-        String absolutePath = path.toString();
-        return absolutePath;
-    }
+		public SadlEclipseGraphVisualizerHandler(SadlActionHandler uiHandler, IProject project, IFile targetFile) {
+			this.uiHandler = uiHandler;
+			this.project = project;
+			this.targetFile = targetFile;
+		}
 
-    protected boolean isCanceled() {
-        return isCanceled;
-    }
+		@Override
+		public void resultSetToGraph(java.nio.file.Path path, ResultSet resultSet, String description,
+				String baseFileName, Orientation orientation, Map<String, String> properties)
+				throws ConfigurationException, IOException {
 
-    protected void setCanceled(boolean isCanceled) {
-        this.isCanceled = isCanceled;
-    }
-
-    protected Resource prepareActionHandler(IProject project, IFile trgtFile) throws ExecutionException {
-        XtextResource res = getXtextResource(project, trgtFile);
-        if (res != null) {
-            if (res instanceof XtextResource) {
-                IResourceValidator validator = res.getResourceServiceProvider().getResourceValidator();
-                validator.validate(res, CheckMode.FAST_ONLY, CancelIndicator.NullImpl);
-                processor = processorProvider.getProcessor(res);
-            }
-            return res;
-        }
-        else {
-            throw new ExecutionException("Unable to obtain a resource for the target file '" + trgtFile.getName() + "'");
-        }
-    }
-
-    protected XtextResource getXtextResource(IProject project, IFile trgtFile) throws ExecutionException {
-        ResourceSet resourceSet = resourceSetProvider.get(project);
-        if (resourceSet != null) {
-            Resource res = resourceSet.getResource(URI.createPlatformResourceURI(trgtFile.getFullPath().toString(), true), true);
-            if (res != null) {
-                if (res instanceof XtextResource) {
-                    return (XtextResource) res;
-                }
-            }
-        }
-        else {
-            throw new ExecutionException("Unable to obtain a resource set for the target file '" + trgtFile.getName() + "'");
-        }
-        return null;
-    }
-
-    protected IGraphVisualizer getVisualizer(IConfigurationManagerForEditing configMgr, Map<String,String> prefMap) {
-        if (visualizer == null) {
-            String renderClass = prefMap.get(SadlPreferences.GRAPH_RENDERER_CLASS.getId());
-            List<IGraphVisualizer> visualizers = configMgr.getAvailableGraphRenderers();
-            if (visualizers != null && visualizers.size() > 0) {
-                visualizer = visualizers.get(0);        // replace this by selection and setting preference
-                for (IGraphVisualizer igv : visualizers) {
-                    if (igv.getClass().getCanonicalName().equals(renderClass)) {
-                        visualizer = igv;
-                        break;
-                    }
-                }
-            }
-        }
-        return visualizer;
-    }
-
-    protected void graphResultSet(IGraphVisualizer iGraphVisualizer, IProject project, String baseFileName, String graphName, String anchorNode,
-            String description, ResultSet rs, IGraphVisualizer.Orientation orientation, boolean openGraph) throws IOException {
-        if (orientation == null) {
-            orientation = IGraphVisualizer.Orientation.TD;
-        }
-        final IGraphVisualizer.Orientation innerOrientation = orientation;
-        String tempDir = convertProjectRelativePathToAbsolutePath(getGraphDir(project));
-        File tmpDirFile = new File(tempDir);
-        tmpDirFile.mkdirs();
-
-        //Perform UI operations from background thread
-        Display.getDefault().asyncExec(new Runnable(){
-            @Override
-            public void run(){
-                try {
-                    iGraphVisualizer.initialize(tempDir, baseFileName, graphName, anchorNode, innerOrientation, description);
-                    iGraphVisualizer.graphResultSetData(rs);
-                    if (openGraph) {
-                        String fileToOpen = iGraphVisualizer.getGraphFileToOpen();
-                        if (fileToOpen != null) {
-                            File fto = new File(fileToOpen);
-                            if (fto.isFile()) {
-                                IFileStore fileStore = EFS.getLocalFileSystem().getStore(fto.toURI());
-                                IWorkbenchPage page = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
-                                try {
-                                    IDE.openEditorOnFileStore(page, fileStore);
-                                }
-                                catch (Throwable t) {
-                                    console.error("Error trying to display graph file '" + fileToOpen + "': " + t.getMessage());
-                                }
-                            }
-                            else if (fileToOpen != null) {
-                                console.error("Failed to open graph file '" + fileToOpen + "'. Try opening it manually.");
-                            }
-                        }
-                    }
-                } catch (IOException e) {
-                        logger.error("Ignoring " + e, e);
-                }
-            }
-        });
-
-    }
-
-    public static String getGraphDir(IProject project) {
-        return project.getFullPath().append("Graphs").toPortableString();
-    }
-
-    protected void createGraphFromResultSet(IGraphVisualizer iGraphVisualizer, IProject project, IFile trgtFile, String baseFileName, String graphName, String anchorNode,
-            String description, ResultSet rs) throws IOException {
-        String tempDir = convertProjectRelativePathToAbsolutePath(getGraphDir(project));
-        File tmpDirFile = new File(tempDir);
-        tmpDirFile.mkdirs();
-        iGraphVisualizer.initialize(tempDir, baseFileName, graphName, anchorNode, IGraphVisualizer.Orientation.TD, description);
-        iGraphVisualizer.graphResultSetData(rs);
-    }
-
-    protected void resultSetToGraph(IProject project, IFile trgtFile, ResultSet rs, String desc, String baseFileName,
-            Orientation orientation, Map<String,String> prefMap)
-            throws ConfigurationException, IOException {
-        if (rs.getColumnCount() >= 3) {
-            String modelFolderUri = convertProjectRelativePathToAbsolutePath(project.getFullPath().append(ResourceManager.OWLDIR).toPortableString());
-            final String format = ConfigurationManager.RDF_XML_ABBREV_FORMAT;
-            IConfigurationManagerForIDE configMgr = ConfigurationManagerForIdeFactory.getConfigurationManagerForIDE(modelFolderUri, format);
-
-            IGraphVisualizer visualizer = getVisualizer(configMgr, prefMap);
-            if (visualizer != null) {
-                graphResultSet(visualizer, project, baseFileName, baseFileName, null, desc, rs, orientation, true);
-            }
-            else {
-                console.error("Unable to find an instance of IGraphVisualizer to render graph for query.\n");
-            }
-        }
-        else {
-            console.error("Unable to render graph for query; ResultSet has less than 3 columns.\n");
-        }
-    }
-
-    public class SadlEclipseGraphVisualizerHandler implements SadlGraphVisualizerHandler {
-
-        private SadlActionHandler uiHandler;
-        private IProject project;
-        private IFile targetFile;
-
-        public SadlEclipseGraphVisualizerHandler(SadlActionHandler uiHandler, IProject project, IFile targetFile) {
-            this.uiHandler = uiHandler;
-            this.project = project;
-            this.targetFile = targetFile;
-        }
-
-        @Override
-        public void resultSetToGraph(java.nio.file.Path path, ResultSet resultSet, String description,
-                String baseFileName, Orientation orientation, Map<String, String> properties)
-                throws ConfigurationException, IOException {
-
-            uiHandler.resultSetToGraph(project, targetFile, resultSet, description, baseFileName, orientation, properties);
-
-        }
-
-    }
+			uiHandler.resultSetToGraph(project, targetFile, resultSet, description, baseFileName, orientation, properties);
+			
+		}
+		
+	}
 
 }

--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui/src/com/ge/research/sadl/ui/handlers/SadlActionHandler.java
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ui/src/com/ge/research/sadl/ui/handlers/SadlActionHandler.java
@@ -73,446 +73,446 @@ import com.ge.research.sadl.utils.ResourceManager;
 import com.ge.research.sadl.utils.SadlConsole;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("restriction")
 public abstract class SadlActionHandler extends AbstractHandler {
 
-	private boolean isCanceled = false;
-	@Inject
-	protected IResourceSetProvider resourceSetProvider;
-	@Inject
-	protected SadlInferenceProcessorProvider processorProvider;
-	@Inject
-	protected IPreferenceValuesProvider preferenceProvider;
-	@Inject
-	protected SadlConsole console;
-	
-	protected ISadlInferenceProcessor processor;
-	
-	private IGraphVisualizer visualizer = null;
-	
-	protected abstract String[] getValidTargetFileTypes();
+    private final Logger logger = LoggerFactory.getLogger(SadlActionHandler.class);
+    private boolean isCanceled = false;
+    @Inject
+    protected IResourceSetProvider resourceSetProvider;
+    @Inject
+    protected SadlInferenceProcessorProvider processorProvider;
+    @Inject
+    protected IPreferenceValuesProvider preferenceProvider;
+    @Inject
+    protected SadlConsole console;
 
-	protected Object[] getCommandTarget(String[] validTargetTypes) throws TranslationException {
-		IProject project = null;
-		IPath trgtFolder = null;
-		IFile trgtFile = null;
-		EObject selectedConcept = null;
-		IPath prjFolder;
+    protected ISadlInferenceProcessor processor;
 
-		IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
-	    if (window != null)
-	    {
-	        ISelection selection = (ISelection) window.getSelectionService().getSelection();
-	        if (!(selection instanceof IStructuredSelection)) {
-	    		IWorkbenchPage page =  window.getActivePage();
-	    		IEditorPart editorPart = page.getActiveEditor();
-	    		if (editorPart.isDirty()) {
-	    		    console.print(MessageType.ERROR, "Model has unsaved changes. Please save before running tests.\n");
-	    		    return null;
-	    		}
-	    		IEditorInput iei = editorPart.getEditorInput();
-	    		if (iei instanceof FileEditorInput) {
-	    			trgtFile = ((FileEditorInput)iei).getFile();
-	    			trgtFolder = trgtFile.getFullPath().removeLastSegments(1);
-	    			IContainer prnt = null;
-	    			do {
-	    				prnt = prnt == null ? trgtFile.getParent() : prnt.getParent();
-	    			} while (prnt != null && !(prnt instanceof IProject));
-	    			if (prnt != null) {
-	    				project = ((IProject)prnt).getProject();
-	    			}
-	    			trgtFolder = trgtFile.getFullPath().removeLastSegments(1);
-	    		}
-	    		else {
-	    			System.err.println("No project is selected for action");
-		        	return null;
-	    		}
-	            if (editorPart instanceof XtextEditor) {
-	                ISelection sel = editorPart.getEditorSite().getSelectionProvider().getSelection();
-	                try {
-	    				if (sel instanceof TextSelection) {
-	    					int offset = ((TextSelection)sel).getOffset();
-	    					int length = ((TextSelection)sel).getLength();
-	    		        	String seltxt = ((XtextEditor)editorPart).getDocument().get(offset, length);
-	    		        	if (seltxt != null && seltxt.length() > 0) {
-	    		        		final TextSelection xtsel = (TextSelection) sel;
-	    		                IXtextDocument document = ((XtextEditor)editorPart).getDocument();
-	    		                EObject selectedObject = document.readOnly(new IUnitOfWork<EObject, XtextResource>() {            
-	    		                    public EObject exec(XtextResource resource) throws Exception {
-	    		                      IParseResult parseResult = resource.getParseResult();
-	    		                            if (parseResult == null) {
-	    		                              return null;
-	    		                            }
-	    		                            ICompositeNode rootNode = parseResult.getRootNode();
-	    		                            int offset = xtsel.getOffset();
-	    		                            ILeafNode node = NodeModelUtils.findLeafNodeAtOffset(rootNode, offset);
-	    		                            return NodeModelUtils.findActualSemanticObjectFor(node);
-	    		                    }
-	    		                });	
-	    		        		if (selectedObject != null) {
-    		    					selectedConcept = selectedObject;
-    		    				}
-    		    				else {
-    		    					console.error("Unable to find a concept with name '" + seltxt + "'");
-    		    				}
-	    		        	}
-	    				}
-	    			} catch (Throwable e) {
-	    				// TODO Auto-generated catch block
-	    				e.printStackTrace();
-	    			}
-	            }
-	        }
-	        else {
-		        Object firstElement = ((IStructuredSelection)selection).getFirstElement();
-		        if (firstElement instanceof IAdaptable)
-		        {
-		        	if (firstElement instanceof org.eclipse.core.resources.IFile) {
-	        			trgtFile = (IFile) firstElement;
-	        			trgtFolder =  ((org.eclipse.core.resources.IFile)firstElement).getParent().getFullPath();	
-	        			project = ((org.eclipse.core.resources.IFile)firstElement).getProject();
-	        			prjFolder = project.getFullPath();
-		        		boolean validType = false;
-		        		for (int i = 0; validTargetTypes != null && i < validTargetTypes.length; i++) {
-		        			if (((org.eclipse.core.resources.IFile)firstElement).getFileExtension().equals(validTargetTypes[i])) {
-		        				validType = true;
-		        				break;
-		        			}
-//		        			else if (validTargetTypes[i].equals("owl")) {
-//		        				// a type of owl is also valid for any file that has a derived (same base name) .owl file in the OwlModels folder--return the file
-//		        				String owlFileName = convertProjectRelativePathToAbsolutePath(
-//		        						project.getFullPath().append(ResourceManager.OWLDIR).append(trgtFile.getFullPath().removeFileExtension().addFileExtension("owl").lastSegment()).toPortableString());
-//		        				if (new File(owlFileName).exists()) {
-//		        					validType = true;
-//		        					break;
-//		        				}
-//		        				else {
-//		        					owlFileName = convertProjectRelativePathToAbsolutePath(
-//			        						project.getFullPath().append(ResourceManager.OWLDIR).append(trgtFile.getFullPath().addFileExtension("owl").lastSegment()).toPortableString());
-//			        				if (new File(owlFileName).exists()) {
-//			        					validType = true;
-//			        					break;
-//			        				}
-//		        				}
-//		        			}
-		        		}
-		        		if (!validType) {
-		        			StringBuilder sb = new StringBuilder();
-		        			if (validTargetTypes == null) {
-		        				sb.append("No valid file types for this command. Select a folder or project");
-		        			}
-		        			else {
-		        				for (int i = 0; i < validTargetTypes.length; i++) {
-		        					if (i > 0) sb.append(", ");
-			        				sb.append(validTargetTypes[i]);
-		        				}
-		        			}
-		        			throw new TranslationException(SadlErrorMessages.FILE_TYPE_ERROR.get(sb.toString()));
-		        		}
-		        	}
-		        	else if (firstElement instanceof IFolder) {
-		        		trgtFolder = ((IFolder)firstElement).getFullPath();
-	        			prjFolder = ((IFolder)firstElement).getProject().getFullPath();
-		        	}
-		        	else if (firstElement instanceof IProject) {
-		        		project = (IProject) firstElement;
-		        		prjFolder = ((IProject)firstElement).getFullPath();
-		        		trgtFolder = prjFolder;
-		        	}
-		        	else {
-		        		// project?
-		        		project = (IProject)((IAdaptable)firstElement).getAdapter(IProject.class);
-			            if (project == null) {
-			            	if (firstElement instanceof org.eclipse.core.resources.IFile) {
-			            		project = ((org.eclipse.core.resources.IFile)firstElement).getProject();
-			            	}
-			            	else if (firstElement instanceof IFolder) {
-			            		project = ((IFolder)firstElement).getProject();
-			            	}
-			            	else {
-			            		throw new TranslationException("Unable to identify file, folder, or project to translate");
-			            	}
-			            }
-			            IPath path = project.getFullPath();
-			            prjFolder = path;
-			            trgtFolder = prjFolder;
-		        	}
-		        }
-	        }
-	        if (project != null || trgtFolder != null || trgtFile != null) {
-	     		Object[] results = new Object[4];
-	    		results[0] = project;
-	   			results[1] = trgtFolder;
-	     		results[2] = trgtFile;
-	     		results[3] = selectedConcept;
-	    		return results;
-	        }
-	        else {
-	        	return null;
-	        }
-	    }
-	    throw new TranslationException("Nothing selected, unable to process command");
-	}
-	
-	protected IFile getTargetFile(String[] validTargetTypes) throws ExecutionException {
-			IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
-			if (window != null) {
-			    ISelection selection = (ISelection) window.getSelectionService().getSelection();
-			    if (selection instanceof TextSelection) {
-			    	XtextEditor editor = EditorUtils.getActiveXtextEditor();
-			    	if (editor != null) {
-				    	IEditorInput editorInput = editor.getEditorInput();
-				    	if (editorInput instanceof IFileEditorInput) {
-				    		return ((IFileEditorInput) editorInput).getFile();
-				    	}
-			    	}
-			    }
-			    if (!(selection instanceof IStructuredSelection) || selection.isEmpty()) {
-			    	throw new ExecutionException("Nothing is selected for action");
-			    }
-			    Object firstElement = ((IStructuredSelection)selection).getFirstElement();
-			    if (firstElement instanceof IAdaptable)
-			    {
-			    	if (firstElement instanceof org.eclipse.core.resources.IFile) {
-			    		String ext = ((org.eclipse.core.resources.IFile)firstElement).getFileExtension();
-			    		boolean validTarget = false;
-			    		for (String s : validTargetTypes) {
-			    			if (s.equals(ext)) {
-			    				validTarget = true;
-			    				break;
-			    			}
-			    		}
-			    		if (validTarget) {
-			    			return  (IFile) firstElement;	
-			    		}
-			    		else {
-			    			throw new ExecutionException("Only files of type .sadl or .test can be targets for this action");
-			    		}
-			    	}
-			    	else {
-			    		throw new ExecutionException("A valid target file must be selected");
-			    	}
-			    }
-			}
-			throw new ExecutionException("No project window selected");
-		}
-	
-	protected Map<String, String> getPreferences(IFile file) {
-		final URI uri = URI.createPlatformResourceURI(file.getFullPath().toString(), true);
-		return getPreferences(uri);
-	}
-	
-	protected Map<String, String> getPreferences(URI uri) {
-		Injector reqInjector = safeGetInjector(SadlActivator.COM_GE_RESEARCH_SADL_SADL);
-		IPreferenceValuesProvider pvp = reqInjector.getInstance(IPreferenceValuesProvider.class);
-		IPreferenceValues preferenceValues = pvp.getPreferenceValues(new XtextResource(uri));
-		if (preferenceValues != null) {
-			Map<String, String> map = new HashMap<String, String>();
-			boolean bval = Boolean.parseBoolean(preferenceValues.getPreference(SadlPreferences.SHOW_TIMING_INFORMATION));
-			if (bval) {
-				map.put(SadlPreferences.SHOW_TIMING_INFORMATION.getId(), "true");
-			}
-			else {
-				map.put(SadlPreferences.SHOW_TIMING_INFORMATION.getId(), "false");
-			}
-			bval = Boolean.parseBoolean(preferenceValues.getPreference(SadlPreferences.VALIDATE_BEFORE_TEST));
-			if (bval) {
-				map.put(SadlPreferences.VALIDATE_BEFORE_TEST.getId(), "true");
-			}
-			else {
-				map.put(SadlPreferences.VALIDATE_BEFORE_TEST.getId(), "false");
-			}
-			bval = Boolean.parseBoolean(preferenceValues.getPreference(SadlPreferences.NAMESPACE_IN_QUERY_RESULTS));
-			if (bval) {
-				map.put(SadlPreferences.NAMESPACE_IN_QUERY_RESULTS.getId(), "true");
-			}
-			else {
-				map.put(SadlPreferences.NAMESPACE_IN_QUERY_RESULTS.getId(), "false");
-			}
-//			preferenceValues.getPreference(SadlPreferences.)
-			return map;
-		}
-		return null;
-	}
+    private IGraphVisualizer visualizer = null;
 
-	protected final Injector safeGetInjector(String name){
-		final AtomicReference<Injector> i = new AtomicReference<Injector>();
-		Display.getDefault().syncExec(new Runnable(){
-			@Override
-			public void run() {
-				i.set(SadlActivator.getInstance().getInjector(name));
-			}
-		});
-		
-		return i.get();
-	}
+    protected abstract String[] getValidTargetFileTypes();
 
-	public static String convertProjectRelativePathToAbsolutePath(String relPath) {
-		IWorkspace workspace = ResourcesPlugin.getWorkspace();
-		IWorkspaceRoot root = workspace.getRoot();
-		IPath path = root.getFile(new Path(relPath)).getLocation();
-		String absolutePath = path.toString();
-		return absolutePath;
-	}
+    protected Object[] getCommandTarget(String[] validTargetTypes) throws TranslationException {
+        IProject project = null;
+        IPath trgtFolder = null;
+        IFile trgtFile = null;
+        EObject selectedConcept = null;
+        IPath prjFolder;
 
-	protected boolean isCanceled() {
-		return isCanceled;
-	}
+        IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+        if (window != null)
+        {
+            ISelection selection = (ISelection) window.getSelectionService().getSelection();
+            if (!(selection instanceof IStructuredSelection)) {
+                IWorkbenchPage page =  window.getActivePage();
+                IEditorPart editorPart = page.getActiveEditor();
+                if (editorPart.isDirty()) {
+                    console.print(MessageType.ERROR, "Model has unsaved changes. Please save before running tests.\n");
+                    return null;
+                }
+                IEditorInput iei = editorPart.getEditorInput();
+                if (iei instanceof FileEditorInput) {
+                    trgtFile = ((FileEditorInput)iei).getFile();
+                    trgtFolder = trgtFile.getFullPath().removeLastSegments(1);
+                    IContainer prnt = null;
+                    do {
+                        prnt = prnt == null ? trgtFile.getParent() : prnt.getParent();
+                    } while (prnt != null && !(prnt instanceof IProject));
+                    if (prnt != null) {
+                        project = ((IProject)prnt).getProject();
+                    }
+                    trgtFolder = trgtFile.getFullPath().removeLastSegments(1);
+                }
+                else {
+                    System.err.println("No project is selected for action");
+                    return null;
+                }
+                if (editorPart instanceof XtextEditor) {
+                    ISelection sel = editorPart.getEditorSite().getSelectionProvider().getSelection();
+                    try {
+                        if (sel instanceof TextSelection) {
+                            int offset = ((TextSelection)sel).getOffset();
+                            int length = ((TextSelection)sel).getLength();
+                            String seltxt = ((XtextEditor)editorPart).getDocument().get(offset, length);
+                            if (seltxt != null && seltxt.length() > 0) {
+                                final TextSelection xtsel = (TextSelection) sel;
+                                IXtextDocument document = ((XtextEditor)editorPart).getDocument();
+                                EObject selectedObject = document.readOnly(new IUnitOfWork<EObject, XtextResource>() {
+                                    public EObject exec(XtextResource resource) throws Exception {
+                                      IParseResult parseResult = resource.getParseResult();
+                                            if (parseResult == null) {
+                                              return null;
+                                            }
+                                            ICompositeNode rootNode = parseResult.getRootNode();
+                                            int offset = xtsel.getOffset();
+                                            ILeafNode node = NodeModelUtils.findLeafNodeAtOffset(rootNode, offset);
+                                            return NodeModelUtils.findActualSemanticObjectFor(node);
+                                    }
+                                });
+                                if (selectedObject != null) {
+                                    selectedConcept = selectedObject;
+                                }
+                                else {
+                                    console.error("Unable to find a concept with name '" + seltxt + "'");
+                                }
+                            }
+                        }
+                    } catch (Throwable e) {
+                        logger.error("Ignoring " + e, e);
+                    }
+                }
+            }
+            else {
+                Object firstElement = ((IStructuredSelection)selection).getFirstElement();
+                if (firstElement instanceof IAdaptable)
+                {
+                    if (firstElement instanceof org.eclipse.core.resources.IFile) {
+                        trgtFile = (IFile) firstElement;
+                        trgtFolder =  ((org.eclipse.core.resources.IFile)firstElement).getParent().getFullPath();
+                        project = ((org.eclipse.core.resources.IFile)firstElement).getProject();
+                        prjFolder = project.getFullPath();
+                        boolean validType = false;
+                        for (int i = 0; validTargetTypes != null && i < validTargetTypes.length; i++) {
+                            if (((org.eclipse.core.resources.IFile)firstElement).getFileExtension().equals(validTargetTypes[i])) {
+                                validType = true;
+                                break;
+                            }
+//                            else if (validTargetTypes[i].equals("owl")) {
+//                                // a type of owl is also valid for any file that has a derived (same base name) .owl file in the OwlModels folder--return the file
+//                                String owlFileName = convertProjectRelativePathToAbsolutePath(
+//                                        project.getFullPath().append(ResourceManager.OWLDIR).append(trgtFile.getFullPath().removeFileExtension().addFileExtension("owl").lastSegment()).toPortableString());
+//                                if (new File(owlFileName).exists()) {
+//                                    validType = true;
+//                                    break;
+//                                }
+//                                else {
+//                                    owlFileName = convertProjectRelativePathToAbsolutePath(
+//                                            project.getFullPath().append(ResourceManager.OWLDIR).append(trgtFile.getFullPath().addFileExtension("owl").lastSegment()).toPortableString());
+//                                    if (new File(owlFileName).exists()) {
+//                                        validType = true;
+//                                        break;
+//                                    }
+//                                }
+//                            }
+                        }
+                        if (!validType) {
+                            StringBuilder sb = new StringBuilder();
+                            if (validTargetTypes == null) {
+                                sb.append("No valid file types for this command. Select a folder or project");
+                            }
+                            else {
+                                for (int i = 0; i < validTargetTypes.length; i++) {
+                                    if (i > 0) sb.append(", ");
+                                    sb.append(validTargetTypes[i]);
+                                }
+                            }
+                            throw new TranslationException(SadlErrorMessages.FILE_TYPE_ERROR.get(sb.toString()));
+                        }
+                    }
+                    else if (firstElement instanceof IFolder) {
+                        trgtFolder = ((IFolder)firstElement).getFullPath();
+                        prjFolder = ((IFolder)firstElement).getProject().getFullPath();
+                    }
+                    else if (firstElement instanceof IProject) {
+                        project = (IProject) firstElement;
+                        prjFolder = ((IProject)firstElement).getFullPath();
+                        trgtFolder = prjFolder;
+                    }
+                    else {
+                        // project?
+                        project = (IProject)((IAdaptable)firstElement).getAdapter(IProject.class);
+                        if (project == null) {
+                            if (firstElement instanceof org.eclipse.core.resources.IFile) {
+                                project = ((org.eclipse.core.resources.IFile)firstElement).getProject();
+                            }
+                            else if (firstElement instanceof IFolder) {
+                                project = ((IFolder)firstElement).getProject();
+                            }
+                            else {
+                                throw new TranslationException("Unable to identify file, folder, or project to translate");
+                            }
+                        }
+                        IPath path = project.getFullPath();
+                        prjFolder = path;
+                        trgtFolder = prjFolder;
+                    }
+                }
+            }
+            if (project != null || trgtFolder != null || trgtFile != null) {
+                 Object[] results = new Object[4];
+                results[0] = project;
+                   results[1] = trgtFolder;
+                 results[2] = trgtFile;
+                 results[3] = selectedConcept;
+                return results;
+            }
+            else {
+                return null;
+            }
+        }
+        throw new TranslationException("Nothing selected, unable to process command");
+    }
 
-	protected void setCanceled(boolean isCanceled) {
-		this.isCanceled = isCanceled;
-	}
+    protected IFile getTargetFile(String[] validTargetTypes) throws ExecutionException {
+            IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+            if (window != null) {
+                ISelection selection = (ISelection) window.getSelectionService().getSelection();
+                if (selection instanceof TextSelection) {
+                    XtextEditor editor = EditorUtils.getActiveXtextEditor();
+                    if (editor != null) {
+                        IEditorInput editorInput = editor.getEditorInput();
+                        if (editorInput instanceof IFileEditorInput) {
+                            return ((IFileEditorInput) editorInput).getFile();
+                        }
+                    }
+                }
+                if (!(selection instanceof IStructuredSelection) || selection.isEmpty()) {
+                    throw new ExecutionException("Nothing is selected for action");
+                }
+                Object firstElement = ((IStructuredSelection)selection).getFirstElement();
+                if (firstElement instanceof IAdaptable)
+                {
+                    if (firstElement instanceof org.eclipse.core.resources.IFile) {
+                        String ext = ((org.eclipse.core.resources.IFile)firstElement).getFileExtension();
+                        boolean validTarget = false;
+                        for (String s : validTargetTypes) {
+                            if (s.equals(ext)) {
+                                validTarget = true;
+                                break;
+                            }
+                        }
+                        if (validTarget) {
+                            return  (IFile) firstElement;
+                        }
+                        else {
+                            throw new ExecutionException("Only files of type .sadl or .test can be targets for this action");
+                        }
+                    }
+                    else {
+                        throw new ExecutionException("A valid target file must be selected");
+                    }
+                }
+            }
+            throw new ExecutionException("No project window selected");
+        }
 
-	protected Resource prepareActionHandler(IProject project, IFile trgtFile) throws ExecutionException {	
-		XtextResource res = getXtextResource(project, trgtFile);
-    	if (res != null) {
-    		if (res instanceof XtextResource) {
-	    		IResourceValidator validator = res.getResourceServiceProvider().getResourceValidator();
-	    		validator.validate(res, CheckMode.FAST_ONLY, CancelIndicator.NullImpl);
-				processor = processorProvider.getProcessor(res);
-    		}
-			return res;
-    	}
-    	else {
-			throw new ExecutionException("Unable to obtain a resource for the target file '" + trgtFile.getName() + "'");
-		}
-	}
-	
-	protected XtextResource getXtextResource(IProject project, IFile trgtFile) throws ExecutionException {
-		ResourceSet resourceSet = resourceSetProvider.get(project);
-		if (resourceSet != null) {
-	    	Resource res = resourceSet.getResource(URI.createPlatformResourceURI(trgtFile.getFullPath().toString(), true), true);
-	    	if (res != null) {
-	    		if (res instanceof XtextResource) {
-	    			return (XtextResource) res;
-	    		}
-	    	}
-		}
-		else {
-			throw new ExecutionException("Unable to obtain a resource set for the target file '" + trgtFile.getName() + "'");
-		}
-		return null;
-	}
+    protected Map<String, String> getPreferences(IFile file) {
+        final URI uri = URI.createPlatformResourceURI(file.getFullPath().toString(), true);
+        return getPreferences(uri);
+    }
 
-	protected IGraphVisualizer getVisualizer(IConfigurationManagerForEditing configMgr, Map<String,String> prefMap) {
-		if (visualizer == null) {
-			String renderClass = prefMap.get(SadlPreferences.GRAPH_RENDERER_CLASS.getId());
-			
-			List<IGraphVisualizer> visualizers = configMgr.getAvailableGraphRenderers();
-					
-			if (visualizers != null && visualizers.size() > 0) {
-				for (IGraphVisualizer igv : visualizers) {
-					if (igv.getClass().getCanonicalName().equals(renderClass)) {
-						return igv;
-					}
-				}
-				visualizer = visualizers.get(0);		// replace this by selection and setting preference
-			}
-		}
-		return visualizer;	
-	}
+    protected Map<String, String> getPreferences(URI uri) {
+        Injector reqInjector = safeGetInjector(SadlActivator.COM_GE_RESEARCH_SADL_SADL);
+        IPreferenceValuesProvider pvp = reqInjector.getInstance(IPreferenceValuesProvider.class);
+        IPreferenceValues preferenceValues = pvp.getPreferenceValues(new XtextResource(uri));
+        if (preferenceValues != null) {
+            Map<String, String> map = new HashMap<String, String>();
+            boolean bval = Boolean.parseBoolean(preferenceValues.getPreference(SadlPreferences.SHOW_TIMING_INFORMATION));
+            if (bval) {
+                map.put(SadlPreferences.SHOW_TIMING_INFORMATION.getId(), "true");
+            }
+            else {
+                map.put(SadlPreferences.SHOW_TIMING_INFORMATION.getId(), "false");
+            }
+            bval = Boolean.parseBoolean(preferenceValues.getPreference(SadlPreferences.VALIDATE_BEFORE_TEST));
+            if (bval) {
+                map.put(SadlPreferences.VALIDATE_BEFORE_TEST.getId(), "true");
+            }
+            else {
+                map.put(SadlPreferences.VALIDATE_BEFORE_TEST.getId(), "false");
+            }
+            bval = Boolean.parseBoolean(preferenceValues.getPreference(SadlPreferences.NAMESPACE_IN_QUERY_RESULTS));
+            if (bval) {
+                map.put(SadlPreferences.NAMESPACE_IN_QUERY_RESULTS.getId(), "true");
+            }
+            else {
+                map.put(SadlPreferences.NAMESPACE_IN_QUERY_RESULTS.getId(), "false");
+            }
+//            preferenceValues.getPreference(SadlPreferences.)
+            return map;
+        }
+        return null;
+    }
 
-	protected void graphResultSet(IGraphVisualizer iGraphVisualizer, IProject project, String baseFileName, String graphName, String anchorNode,
-			String description, ResultSet rs, IGraphVisualizer.Orientation orientation, boolean openGraph) throws IOException {
-		if (orientation == null) {
-			orientation = IGraphVisualizer.Orientation.TD;
-		}
-		final IGraphVisualizer.Orientation innerOrientation = orientation;
-		String tempDir = convertProjectRelativePathToAbsolutePath(getGraphDir(project)); 
-		File tmpDirFile = new File(tempDir);
-		tmpDirFile.mkdirs();
-		
-		//Perform UI operations from background thread
-		Display.getDefault().asyncExec(new Runnable(){
-			@Override
-			public void run(){
-				try {
-					iGraphVisualizer.initialize(tempDir, baseFileName, graphName, anchorNode, innerOrientation, description);
-					iGraphVisualizer.graphResultSetData(rs);
-					if (openGraph) {
-						String fileToOpen = iGraphVisualizer.getGraphFileToOpen();
-						if (fileToOpen != null) {
-							File fto = new File(fileToOpen);
-							if (fto.isFile()) {
-								IFileStore fileStore = EFS.getLocalFileSystem().getStore(fto.toURI());
-								IWorkbenchPage page = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
-								try {
-									IDE.openEditorOnFileStore(page, fileStore);
-								}
-								catch (Throwable t) {
-									console.error("Error trying to display graph file '" + fileToOpen + "': " + t.getMessage());
-								}
-							}
-							else if (fileToOpen != null) {
-								console.error("Failed to open graph file '" + fileToOpen + "'. Try opening it manually.");
-							}
-						}
-					}
-				} catch (IOException e) {
-					// TODO Auto-generated catch block
-					e.printStackTrace();
-				}
-			}
-		});
-		
-	}
+    protected final Injector safeGetInjector(String name){
+        final AtomicReference<Injector> i = new AtomicReference<Injector>();
+        Display.getDefault().syncExec(new Runnable(){
+            @Override
+            public void run() {
+                i.set(SadlActivator.getInstance().getInjector(name));
+            }
+        });
 
-	public static String getGraphDir(IProject project) {
-		return project.getFullPath().append("Graphs").toPortableString();
-	}
-	
-	protected void createGraphFromResultSet(IGraphVisualizer iGraphVisualizer, IProject project, IFile trgtFile, String baseFileName, String graphName, String anchorNode,
-			String description, ResultSet rs) throws IOException {
-		String tempDir = convertProjectRelativePathToAbsolutePath(getGraphDir(project)); 
-		File tmpDirFile = new File(tempDir);
-		tmpDirFile.mkdirs();
-		iGraphVisualizer.initialize(tempDir, baseFileName, graphName, anchorNode, IGraphVisualizer.Orientation.TD, description);
-		iGraphVisualizer.graphResultSetData(rs);
-	}
-	
-	protected void resultSetToGraph(IProject project, IFile trgtFile, ResultSet rs, String desc, String baseFileName, 
-			Orientation orientation, Map<String,String> prefMap)
-			throws ConfigurationException, IOException {
-		if (rs.getColumnCount() >= 3) {
-			String modelFolderUri = convertProjectRelativePathToAbsolutePath(project.getFullPath().append(ResourceManager.OWLDIR).toPortableString()); 
-			final String format = ConfigurationManager.RDF_XML_ABBREV_FORMAT;
-			IConfigurationManagerForIDE configMgr = ConfigurationManagerForIdeFactory.getConfigurationManagerForIDE(modelFolderUri, format);
-	
-			IGraphVisualizer visualizer = getVisualizer(configMgr, prefMap);
-			if (visualizer != null) {
-				graphResultSet(visualizer, project, baseFileName, baseFileName, null, desc, rs, orientation, true);
-			}
-			else {
-				console.error("Unable to find an instance of IGraphVisualizer to render graph for query.\n");
-			}
-		}
-		else {
-			console.error("Unable to render graph for query; ResultSet has less than 3 columns.\n");
-		}
-	}
-	
-	public class SadlEclipseGraphVisualizerHandler implements SadlGraphVisualizerHandler {
-		
-		private SadlActionHandler uiHandler;
-		private IProject project;
-		private IFile targetFile;
+        return i.get();
+    }
 
-		public SadlEclipseGraphVisualizerHandler(SadlActionHandler uiHandler, IProject project, IFile targetFile) {
-			this.uiHandler = uiHandler;
-			this.project = project;
-			this.targetFile = targetFile;
-		}
+    public static String convertProjectRelativePathToAbsolutePath(String relPath) {
+        IWorkspace workspace = ResourcesPlugin.getWorkspace();
+        IWorkspaceRoot root = workspace.getRoot();
+        IPath path = root.getFile(new Path(relPath)).getLocation();
+        String absolutePath = path.toString();
+        return absolutePath;
+    }
 
-		@Override
-		public void resultSetToGraph(java.nio.file.Path path, ResultSet resultSet, String description,
-				String baseFileName, Orientation orientation, Map<String, String> properties)
-				throws ConfigurationException, IOException {
+    protected boolean isCanceled() {
+        return isCanceled;
+    }
 
-			uiHandler.resultSetToGraph(project, targetFile, resultSet, description, baseFileName, orientation, properties);
-			
-		}
-		
-	}
+    protected void setCanceled(boolean isCanceled) {
+        this.isCanceled = isCanceled;
+    }
+
+    protected Resource prepareActionHandler(IProject project, IFile trgtFile) throws ExecutionException {
+        XtextResource res = getXtextResource(project, trgtFile);
+        if (res != null) {
+            if (res instanceof XtextResource) {
+                IResourceValidator validator = res.getResourceServiceProvider().getResourceValidator();
+                validator.validate(res, CheckMode.FAST_ONLY, CancelIndicator.NullImpl);
+                processor = processorProvider.getProcessor(res);
+            }
+            return res;
+        }
+        else {
+            throw new ExecutionException("Unable to obtain a resource for the target file '" + trgtFile.getName() + "'");
+        }
+    }
+
+    protected XtextResource getXtextResource(IProject project, IFile trgtFile) throws ExecutionException {
+        ResourceSet resourceSet = resourceSetProvider.get(project);
+        if (resourceSet != null) {
+            Resource res = resourceSet.getResource(URI.createPlatformResourceURI(trgtFile.getFullPath().toString(), true), true);
+            if (res != null) {
+                if (res instanceof XtextResource) {
+                    return (XtextResource) res;
+                }
+            }
+        }
+        else {
+            throw new ExecutionException("Unable to obtain a resource set for the target file '" + trgtFile.getName() + "'");
+        }
+        return null;
+    }
+
+    protected IGraphVisualizer getVisualizer(IConfigurationManagerForEditing configMgr, Map<String,String> prefMap) {
+        if (visualizer == null) {
+            String renderClass = prefMap.get(SadlPreferences.GRAPH_RENDERER_CLASS.getId());
+            List<IGraphVisualizer> visualizers = configMgr.getAvailableGraphRenderers();
+            if (visualizers != null && visualizers.size() > 0) {
+                visualizer = visualizers.get(0);        // replace this by selection and setting preference
+                for (IGraphVisualizer igv : visualizers) {
+                    if (igv.getClass().getCanonicalName().equals(renderClass)) {
+                        visualizer = igv;
+                        break;
+                    }
+                }
+            }
+        }
+        return visualizer;
+    }
+
+    protected void graphResultSet(IGraphVisualizer iGraphVisualizer, IProject project, String baseFileName, String graphName, String anchorNode,
+            String description, ResultSet rs, IGraphVisualizer.Orientation orientation, boolean openGraph) throws IOException {
+        if (orientation == null) {
+            orientation = IGraphVisualizer.Orientation.TD;
+        }
+        final IGraphVisualizer.Orientation innerOrientation = orientation;
+        String tempDir = convertProjectRelativePathToAbsolutePath(getGraphDir(project));
+        File tmpDirFile = new File(tempDir);
+        tmpDirFile.mkdirs();
+
+        //Perform UI operations from background thread
+        Display.getDefault().asyncExec(new Runnable(){
+            @Override
+            public void run(){
+                try {
+                    iGraphVisualizer.initialize(tempDir, baseFileName, graphName, anchorNode, innerOrientation, description);
+                    iGraphVisualizer.graphResultSetData(rs);
+                    if (openGraph) {
+                        String fileToOpen = iGraphVisualizer.getGraphFileToOpen();
+                        if (fileToOpen != null) {
+                            File fto = new File(fileToOpen);
+                            if (fto.isFile()) {
+                                IFileStore fileStore = EFS.getLocalFileSystem().getStore(fto.toURI());
+                                IWorkbenchPage page = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
+                                try {
+                                    IDE.openEditorOnFileStore(page, fileStore);
+                                }
+                                catch (Throwable t) {
+                                    console.error("Error trying to display graph file '" + fileToOpen + "': " + t.getMessage());
+                                }
+                            }
+                            else if (fileToOpen != null) {
+                                console.error("Failed to open graph file '" + fileToOpen + "'. Try opening it manually.");
+                            }
+                        }
+                    }
+                } catch (IOException e) {
+                        logger.error("Ignoring " + e, e);
+                }
+            }
+        });
+
+    }
+
+    public static String getGraphDir(IProject project) {
+        return project.getFullPath().append("Graphs").toPortableString();
+    }
+
+    protected void createGraphFromResultSet(IGraphVisualizer iGraphVisualizer, IProject project, IFile trgtFile, String baseFileName, String graphName, String anchorNode,
+            String description, ResultSet rs) throws IOException {
+        String tempDir = convertProjectRelativePathToAbsolutePath(getGraphDir(project));
+        File tmpDirFile = new File(tempDir);
+        tmpDirFile.mkdirs();
+        iGraphVisualizer.initialize(tempDir, baseFileName, graphName, anchorNode, IGraphVisualizer.Orientation.TD, description);
+        iGraphVisualizer.graphResultSetData(rs);
+    }
+
+    protected void resultSetToGraph(IProject project, IFile trgtFile, ResultSet rs, String desc, String baseFileName,
+            Orientation orientation, Map<String,String> prefMap)
+            throws ConfigurationException, IOException {
+        if (rs.getColumnCount() >= 3) {
+            String modelFolderUri = convertProjectRelativePathToAbsolutePath(project.getFullPath().append(ResourceManager.OWLDIR).toPortableString());
+            final String format = ConfigurationManager.RDF_XML_ABBREV_FORMAT;
+            IConfigurationManagerForIDE configMgr = ConfigurationManagerForIdeFactory.getConfigurationManagerForIDE(modelFolderUri, format);
+
+            IGraphVisualizer visualizer = getVisualizer(configMgr, prefMap);
+            if (visualizer != null) {
+                graphResultSet(visualizer, project, baseFileName, baseFileName, null, desc, rs, orientation, true);
+            }
+            else {
+                console.error("Unable to find an instance of IGraphVisualizer to render graph for query.\n");
+            }
+        }
+        else {
+            console.error("Unable to render graph for query; ResultSet has less than 3 columns.\n");
+        }
+    }
+
+    public class SadlEclipseGraphVisualizerHandler implements SadlGraphVisualizerHandler {
+
+        private SadlActionHandler uiHandler;
+        private IProject project;
+        private IFile targetFile;
+
+        public SadlEclipseGraphVisualizerHandler(SadlActionHandler uiHandler, IProject project, IFile targetFile) {
+            this.uiHandler = uiHandler;
+            this.project = project;
+            this.targetFile = targetFile;
+        }
+
+        @Override
+        public void resultSetToGraph(java.nio.file.Path path, ResultSet resultSet, String description,
+                String baseFileName, Orientation orientation, Map<String, String> properties)
+                throws ConfigurationException, IOException {
+
+            uiHandler.resultSetToGraph(project, targetFile, resultSet, description, baseFileName, orientation, properties);
+
+        }
+
+    }
 
 }


### PR DESCRIPTION
Andy, Abha asked me to make ExecuteCommand create graphs too.  These changes should be merged into the development branch after you review them.

Previously ExecuteCommand would run the inference processor but not the run inference handler which also displays the results and creates the graphs in addition to running the inference processor.  Now ExecuteCommand will hand the entire job off to the run inference handler instead of the run inference processor.

The key part to making these changes work is adding new Guice bindings to SADLCliAppRuntimeModule so that the run inference handler will be able to print messages, find project directories, and create graphs successfully.

We also need the com.ge.research.sadl.ide bundle to export com.ge.research.ide.utils so SADLCliAppRuntimeModule can import SadlIdeProjectHelper from it.

Also remove -console from ExecuteCommand.sh and ExecuteCommand.cmd scripts since it just produces an osgi> prompt that we don't need in the output.  Also improve log4j.properties in case we want to use it (ExecuteCommand also configures logging programmatically anyway).

Update SadlConfiguration.xml (and ExecuteCommand) to include new SADL properties that were added to SADL recently.

Reformat ExecuteCommand and rest of its package classes using Google Java Formatter.

Make GraphVizVisualizer, SadlActionHandler, and ExecuteCommand use SL4J Logger API to ensure their logging will be handled appropriately.

Note that more than half of SADL uses SLF4J Logger but rest of SADL still uses Log4j Logger and probably should be converted to use SLF4J so that all logging will end up in one place.