### PR TITLE
GH-374: Load the resource for the inferencer if it was not loaded yet.

### DIFF
--- a/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ide/src/com/ge/research/sadl/ide/handlers/SadlIdeActionHandler.xtend
+++ b/sadl3/com.ge.research.sadl.parent/com.ge.research.sadl.ide/src/com/ge/research/sadl/ide/handlers/SadlIdeActionHandler.xtend
@@ -85,8 +85,8 @@ class SadlIdeActionHandler {
 	 * the validation on it and return with the resource. Otherwise, returns {@code null}. 
 	 */
 	protected def XtextResource findAndPrepareResource(ResourceSet resourceSet, Path resourcePath) {
-		val uri = resourcePath.toUri.toEmfUri;
-		val resource = resourceSet.getResource(uri, false);
+		val uri = projectHelper.toUri(resourcePath).toEmfUri;
+		val resource = resourceSet.getResource(uri, true);
 		if (resource instanceof XtextResource) {
 			return resource.prepareResource;
 		}


### PR DESCRIPTION
Made sure, the `nio.file.Path` is converted to the appropriate
`java.net.URI` first, then mapped into an EMF URI.

Closes #374.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

@crapo, can you please check the proposed changes? Without this, the `resource` was always `null`. With my modifications, I could load the resources:
 - `TestSadl3Ide/testImportApvf.sadl`,
 - `TestSadl3Ide/GeorgeAndMartha.sadl`, and
 - `TestSadl3Ide/TestGraphPatternBuiltins.sadl`
 

However, the number of tests was 1 and the test was failing:

```
Testing of suite '/Users/akos.kitta/dev/wss/sadl/ws/runtime-configuration-assert/TestSadl3Ide/TestSuite1.test' requested.
Test failed: George is v0(George Eq? v0)
Completed test suite'/Users/akos.kitta/dev/wss/sadl/ws/runtime-configuration-assert/TestSadl3Ide/TestSuite1.test': passed 0 of 1 tests.
```